### PR TITLE
[Feature/error code] 에러코드 커스텀 반영, 테스트

### DIFF
--- a/src/main/java/hatch/hatchserver2023/global/common/response/CommonResponse.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/CommonResponse.java
@@ -15,13 +15,13 @@ import java.time.format.DateTimeFormatter;
 public class CommonResponse {
     private final String timeStamp = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
             .format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss"));
-    private final int code;
+    private final String code;
     private final String message;
     private final Object data;
 
     public static CommonResponse toResponse(StatusCode statusCode, Object data) {
         return CommonResponse.builder()
-                .code(statusCode.getCode().value())
+                .code(statusCode.getCode())
                 .message(statusCode.getMessage())
                 .data(data)
                 .build();
@@ -29,14 +29,14 @@ public class CommonResponse {
 
     public static CommonResponse toResponse(StatusCode statusCode) {
         return CommonResponse.builder()
-                .code(statusCode.getCode().value())
+                .code(statusCode.getCode())
                 .message(statusCode.getMessage())
                 .build();
     }
 
     public static CommonResponse toErrorResponse(StatusCode statusCode, String message) {
         return CommonResponse.builder()
-                .code(statusCode.getCode().value())
+                .code(statusCode.getCode())
                 .message(message)
                 .build();
     }
@@ -44,7 +44,7 @@ public class CommonResponse {
 
     public static CommonResponse toErrorResponse(StatusCode statusCode) {
         return CommonResponse.builder()
-                .code(statusCode.getCode().value())
+                .code(statusCode.getCode())
                 .message(statusCode.getMessage())
                 .build();
     }

--- a/src/main/java/hatch/hatchserver2023/global/common/response/code/CommonCode.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/code/CommonCode.java
@@ -3,15 +3,15 @@ package hatch.hatchserver2023.global.common.response.code;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-@Getter
+//@Getter
 public enum CommonCode implements StatusCode {
-    OK(HttpStatus.OK, "C200", "정상 처리"), //200
-    CREATED(HttpStatus.CREATED, "C201", "새로운 리소스 생성"), //201
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "C400", "잘못된 요청"), //400
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C401", "인증되지 않음"), //401
-    FORBIDDEN(HttpStatus.FORBIDDEN, "C403", "권한 부족"), //403
-    NOT_FOUND(HttpStatus.NOT_FOUND, "C404", "요청 리소스를 찾을 수 없음"), //404
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C500", "서버 내부 오류"); //500
+    OK(HttpStatus.OK, "200", "정상 처리"), //200
+    CREATED(HttpStatus.CREATED, "201", "새로운 리소스 생성"), //201
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "400", "잘못된 요청"), //400
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "401", "인증되지 않음"), //401
+    FORBIDDEN(HttpStatus.FORBIDDEN, "403", "권한 부족"), //403
+    NOT_FOUND(HttpStatus.NOT_FOUND, "404", "요청 리소스를 찾을 수 없음"), //404
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "500", "서버 내부 오류"); //500
 
     private HttpStatus status;
     private String code;
@@ -21,5 +21,20 @@ public enum CommonCode implements StatusCode {
         this.status = status;
         this.code = code;
         this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return DomainLabel.COMMON.getInitial() + code;
+    }
+
+    @Override
+    public String getMessage() {
+        return DomainLabel.COMMON.getLabel() + " " + message;
     }
 }

--- a/src/main/java/hatch/hatchserver2023/global/common/response/code/CommonCode.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/code/CommonCode.java
@@ -5,18 +5,20 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum CommonCode implements StatusCode {
-    OK(HttpStatus.OK, "정상 처리"), //200
-    CREATED(HttpStatus.CREATED,"새로운 리소스 생성"), //201
-    BAD_REQUEST(HttpStatus.BAD_REQUEST,"잘못된 요청"), //400
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"인증되지 않음"), //401
-    FORBIDDEN(HttpStatus.FORBIDDEN,"권한 부족"), //403
-    NOT_FOUND(HttpStatus.NOT_FOUND,"요청 리소스를 찾을 수 없음"), //404
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"서버 내부 오류"); //500
+    OK(HttpStatus.OK, "C200", "정상 처리"), //200
+    CREATED(HttpStatus.CREATED, "C201", "새로운 리소스 생성"), //201
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "C400", "잘못된 요청"), //400
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C401", "인증되지 않음"), //401
+    FORBIDDEN(HttpStatus.FORBIDDEN, "C403", "권한 부족"), //403
+    NOT_FOUND(HttpStatus.NOT_FOUND, "C404", "요청 리소스를 찾을 수 없음"), //404
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C500", "서버 내부 오류"); //500
 
-    private HttpStatus code;
+    private HttpStatus status;
+    private String code;
     private String message;
 
-    CommonCode(HttpStatus code, String message){
+    CommonCode(HttpStatus status, String code, String message){
+        this.status = status;
         this.code = code;
         this.message = message;
     }

--- a/src/main/java/hatch/hatchserver2023/global/common/response/code/CommonCode.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/code/CommonCode.java
@@ -35,6 +35,6 @@ public enum CommonCode implements StatusCode {
 
     @Override
     public String getMessage() {
-        return DomainLabel.COMMON.getLabel() + " " + message;
+        return DomainLabel.COMMON.getLabel() + message;
     }
 }

--- a/src/main/java/hatch/hatchserver2023/global/common/response/code/DomainLabel.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/code/DomainLabel.java
@@ -2,9 +2,9 @@ package hatch.hatchserver2023.global.common.response.code;
 
 import lombok.Getter;
 
-@Getter
+//@Getter
 public enum DomainLabel {
-    COMMON("C", "[공통]"),
+    COMMON("COMMON", "공통"),
     ;
     private final String initial;
     private final String label;
@@ -12,5 +12,13 @@ public enum DomainLabel {
     DomainLabel(String initial, String label) {
         this.initial = initial;
         this.label = label;
+    }
+
+    public String getInitial() {
+        return this.initial + "-";
+    }
+
+    public String getLabel() {
+        return "[" + this.label + "] ";
     }
 }

--- a/src/main/java/hatch/hatchserver2023/global/common/response/code/DomainLabel.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/code/DomainLabel.java
@@ -1,0 +1,16 @@
+package hatch.hatchserver2023.global.common.response.code;
+
+import lombok.Getter;
+
+@Getter
+public enum DomainLabel {
+    COMMON("C", "[공통]"),
+    ;
+    private final String initial;
+    private final String label;
+
+    DomainLabel(String initial, String label) {
+        this.initial = initial;
+        this.label = label;
+    }
+}

--- a/src/main/java/hatch/hatchserver2023/global/common/response/code/StatusCode.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/code/StatusCode.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public interface StatusCode {
     String name();
-    HttpStatus getCode();
+    HttpStatus getStatus();
+    String getCode();
     String getMessage();
 }

--- a/src/main/java/hatch/hatchserver2023/global/common/response/exception/GlobalExceptionHandler.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/exception/GlobalExceptionHandler.java
@@ -78,14 +78,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     private ResponseEntity<Object> handleExceptionInternal(StatusCode code){
         CommonResponse errorResponse = CommonResponse.toErrorResponse(code);
         return ResponseEntity
-                .status(code.getCode())
+                .status(code.getStatus())
                 .body(errorResponse);
     }
 
     private ResponseEntity<Object> handleExceptionInternal(StatusCode code, String message){
         CommonResponse errorResponse = CommonResponse.toErrorResponse(code, message);
         return ResponseEntity
-                .status(code.getCode())
+                .status(code.getStatus())
                 .body(errorResponse);
     }
 }

--- a/src/test/java/hatch/hatchserver2023/global/common/response/CommonResponseTest.java
+++ b/src/test/java/hatch/hatchserver2023/global/common/response/CommonResponseTest.java
@@ -18,7 +18,7 @@ class CommonResponseTest {
         //then
         CommonResponse response = CommonResponse.toResponse(code);
         assertThat(response.getCode())
-                .isEqualTo("C200");
+                .isEqualTo("COMMON-200");
         assertThat(response.getMessage())
                 .isEqualTo("[공통] 정상 처리");
     }
@@ -33,7 +33,7 @@ class CommonResponseTest {
         //then
         CommonResponse response = CommonResponse.toResponse(code);
         assertThat(response.getCode())
-                .isEqualTo("C400");
+                .isEqualTo("COMMON-400");
         assertThat(response.getMessage())
                 .isEqualTo("[공통] 잘못된 요청");
     }

--- a/src/test/java/hatch/hatchserver2023/global/common/response/CommonResponseTest.java
+++ b/src/test/java/hatch/hatchserver2023/global/common/response/CommonResponseTest.java
@@ -1,0 +1,41 @@
+package hatch.hatchserver2023.global.common.response;
+
+import hatch.hatchserver2023.global.common.response.code.CommonCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommonResponseTest {
+
+    @Test
+    void toResponse() {
+        //given
+        CommonCode code = CommonCode.OK;
+
+        //when
+        //then
+        CommonResponse response = CommonResponse.toResponse(code);
+        assertThat(response.getCode())
+                .isEqualTo("C200");
+        assertThat(response.getMessage())
+                .isEqualTo("[공통] 정상 처리");
+    }
+
+
+    @Test
+    void toErrorResponse() {
+        //given
+        CommonCode code = CommonCode.BAD_REQUEST;
+
+        //when
+        //then
+        CommonResponse response = CommonResponse.toResponse(code);
+        assertThat(response.getCode())
+                .isEqualTo("C400");
+        assertThat(response.getMessage())
+                .isEqualTo("[공통] 잘못된 요청");
+    }
+
+}

--- a/src/test/java/hatch/hatchserver2023/global/common/response/code/CommonCodeTest.java
+++ b/src/test/java/hatch/hatchserver2023/global/common/response/code/CommonCodeTest.java
@@ -23,7 +23,7 @@ class CommonCodeTest {
         //when
         //then
         assertThat(CommonCode.OK.getCode())
-                .isEqualTo("C200");
+                .isEqualTo("COMMON-200");
     }
 
     @Test

--- a/src/test/java/hatch/hatchserver2023/global/common/response/code/CommonCodeTest.java
+++ b/src/test/java/hatch/hatchserver2023/global/common/response/code/CommonCodeTest.java
@@ -1,0 +1,37 @@
+package hatch.hatchserver2023.global.common.response.code;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommonCodeTest {
+
+    @Test
+    void getStatus() {
+        //given
+        //when
+        //then
+        assertThat(CommonCode.OK.getStatus())
+                .isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void getCode() {
+        //given
+        //when
+        //then
+        assertThat(CommonCode.OK.getCode())
+                .isEqualTo("C200");
+    }
+
+    @Test
+    void getMessage() {
+        //given
+        //when
+        //then
+        assertThat(CommonCode.OK.getMessage())
+                .isEqualTo("[공통] 정상 처리");
+    }
+}


### PR DESCRIPTION
🏷️ Jira issue : HH-127

― PR 유형 ―
- 기존 기능 수정


<br>

## 📑 작업 내용 
1. 아래 작업 내용들 테스트 코드 작성하여 테스트 실행
  _저 이제 테스트코드 막 활용하고 이래요 넘 기분 조아유_

2. 에러 코드 커스텀 반영 

3. DomainLabel 클래스 생성 : 커스텀 코드에 붙는 값들 enum화

(추가 작업)
4. 도메인 이름 형식 변경, DomainLabel 의 enum값에서 형식적인 것들( - 나 [ ] 같은 기호)은 제외함
제외한 기호들은 DomainLabel의 getter를 직접 작성하여 get메서드 사용 시 붙도록 수정


<br>

## 📌 주요 집중 포인트
### 2. 에러 코드 커스텀 반영 
  기존 CommonCode 는 두 필드가 있었습니다.
  ```
    private HttpStatus code;
    private String message;
  ```
  여기서 code 값이 커스텀 에러코드 표현을 위한 String 데이터로 바뀌고,
  기존 code 값의 이름을 status로 변경했습니다.
  현재 CommonCode 는 아래와 같은 세 필드를 갖습니다.
  ```
    private HttpStatus status;
    private String code;
    private String message;
  ```
  이에 따라 기존 status code 에 있던 메서드 중 getCode() 의 반환값이 String으로 수정되었고, getStatus() 가 추가되었습니다.
  CommonCode를 사용하던 CommonResponse와 GlobalExceptionHandler도 수정 반영했습니다.

<br>

### 3. DomainLabel 클래스 생성 : 커스텀 코드에 붙는 값들 enum화
  위의 작업 후에 CommonCode의 enum들이 이렇게 표현되었는데요.
  ```
  @Getter
  public enum CommonCode implements StatusCode {
      OK(HttpStatus.OK, "C200", "정상 처리"), //200
      CREATED(HttpStatus.CREATED, "C201", "새로운 리소스 생성"), //201
      BAD_REQUEST(HttpStatus.BAD_REQUEST, "C400", "잘못된 요청"), //400
      UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C401", "인증되지 않음"), //401
      FORBIDDEN(HttpStatus.FORBIDDEN, "C403", "권한 부족"), //403
      NOT_FOUND(HttpStatus.NOT_FOUND, "C404", "요청 리소스를 찾을 수 없음"), //404
      INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C500", "서버 내부 오류"); //500
  ```
  커스텀 코드 앞에 붙는 영어 이니셜 "C"가 중복된다는 느낌을 받았고, 
  이를 수작업으로 입력해줘야 하는 점이 관리가 어렵다고 판단했습니다.
  또한 "정상 처리"와 같은 메세지 앞에도 어떤 도메인에 대한 에러인지 말로 알아볼 수 있도록 명시하고 싶었습니다.
  예를 들어 CommonCode에서는 "정상 처리" 가 아닌 "[공통] 정상 처리" 이런 식으로요.
  그래서 다음과 같이 도메인별 응답 라벨을 모아두는 enum을 생성했습니다.
  ```

  @Getter
  public enum DomainLabel {
      COMMON("C", "[공통]"),
      ;
      private final String initial;
      private final String label;
  ```
  그리고 CommonCode의 Getter들을 lombok으로 자동생성하는 대신 직접 작성하여
  DomainLabel 클래스를 사용한 값을 반환하도록 변경해보았습니다.
  (변경 결과는 코드 참조 바랍니다)

최종적으로 에러코드 커스텀 반영 전과 후 응답을 비교해서 보여드리겠습니다.
- 변경 전
  ```
  {
      "timeStamp": "2023/03/01 22:17:18",
      "code": 200,
      "message": "정상 처리"
  }
  ```
- 변경 후

  ```
  {
      "timeStamp": "2023/03/01 22:17:18",
      "code": "C200",
      "message": "[공통] 정상 처리"
  }
  ```

제 마음대로 바꾼 부분도 있어서
원래대로 했으면 하는 부분이나 더 개선할 점이 있다면 피드백 바랍니다.


<br>

## 🔥 어려웠던 부분 & 트러블 슈팅



<br>

## 🐣 앞으로 할 일
- 커스텀 코드를 쉽고 예쁘게 문서화(명세)할 방법 알아볼 예정 (Spring Rest Docs 등)
- 그 후에는 개발 쪽보다는 지라 백로그 하나씩 뿌실 것 같아요


<br>

### 📎기타 사항
참고로 오늘 프론트에 본프젝은 커스텀코드 줄거라고 했더니 엄청 좋아하더라구요
자세하게 나와서 좋을 것 같다고 하시던데
프론트에서 기대하는 위치(컨트롤러 로직도 안타고 400뜨거나..)에서까지 자세히 응답해줄 수 있을지는...... 자신없음

설명할 게 많아지니까 마크다운으로 예쁘게 쓰기는 한계가 있는지 
색도 없고 가독성이 막 좋진 않은 것 같네요...... 좀더 읽기좋게 쓸 방법 있을까요 수정 막 하셔두 돼요