### PR TITLE
Update : Change to put User instead of just uuid in Authentication principal (HH-182)

### DIFF
--- a/src/main/java/hatch/hatchserver2023/domain/TestController.java
+++ b/src/main/java/hatch/hatchserver2023/domain/TestController.java
@@ -13,6 +13,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
@@ -61,9 +62,10 @@ public class TestController {
 
     @PreAuthorize("hasAnyRole('ROLE_ANONYMOUS')")
     @GetMapping("/auth/anonymous")
-    public ResponseEntity<CommonResponse> authAnonymous(@AuthenticationPrincipal Object principal) {
+    public ResponseEntity<CommonResponse> authAnonymous(@AuthenticationPrincipal User principal) { //principal == null
         log.info("[API] GET /api/v1/test/auth/anonymous");
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        checkPrincipal(principal);
         return ResponseEntity.ok()
                 .body(CommonResponse.toResponse(CommonCode.OK, "authAnonymous : "+authentication.toString()));
     }
@@ -71,10 +73,22 @@ public class TestController {
     //    @Secured("ROLE_USER")
     @PreAuthorize("hasAnyRole('ROLE_USER')")
     @GetMapping("/auth/user")
-    public ResponseEntity<CommonResponse> authUser(@AuthenticationPrincipal Object principal) {
+    public ResponseEntity<CommonResponse> authUser(@AuthenticationPrincipal User principal) { //@AuthenticationPrincipal 어노테이션으로 로그인된 User 객체 받아올 수 있음
         log.info("[API] GET /api/v1/test/auth/user");
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication(); //인증정보만 필요하면 이렇게도 가져올 수 있음
+        log.info("principal.getNickName: "+principal.getNickname()); //user 객체라서 바로 user 정보에 접근 가능
+        checkPrincipal(principal);
         return ResponseEntity.ok()
                 .body(CommonResponse.toResponse(CommonCode.OK, "authUser : "+authentication.toString()));
+    }
+
+    private void checkPrincipal(Object principal) {
+        log.info("principal: "+principal);
+        if(principal instanceof User) {
+            User user = (User) principal;
+            log.info("type is user : "+user.getUuid());
+        } else{
+            log.info("type is not user");
+        }
     }
 }

--- a/src/main/java/hatch/hatchserver2023/global/config/security/jwt/JwtProvider.java
+++ b/src/main/java/hatch/hatchserver2023/global/config/security/jwt/JwtProvider.java
@@ -133,7 +133,8 @@ public class JwtProvider {
         String uuid = getUserPK(token);
         User user = getUser(uuid);
         log.info("jwtProvider getAuthentication :  user " + user);
-        Authentication authentication = new UsernamePasswordAuthenticationToken(user.getUuid(), "", user.getAuthorities());  //principal에 uuid, authorities 설정
+//        Authentication authentication = new UsernamePasswordAuthenticationToken(user.getUuid(), "", user.getAuthorities());  //principal에 uuid, authorities 설정
+        Authentication authentication = new UsernamePasswordAuthenticationToken(user, "", user.getAuthorities());  //principal에 User 객체, authorities 설정
         return authentication;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   jpa:
     database: mysql
     hibernate:
-      ddl-auto: update #create, create-drop, none, update
+      ddl-auto: none #create, create-drop, none, update
       naming:
         physical-strategy: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy # set DB column name by snake case
     show-sql: true


### PR DESCRIPTION
🏷️ Jira issue : HH-182

― PR 유형 ―
- 기존 기능 수정


<br>

## 📑 작업 내용 
- 시큐리티에 저장해둘 현재 사용자 정보를 uuid 에서 User 객체로 변경
@AuthenticationPrincipal 어노테이션으로 바로 User 객체를 가져와서 사용할 수 있도록 하였습니다.
식별자(uuid 등)만 있다면 사용자 정보 필요할 때 DB 또 갔다와야 하니까 비효율적이라서 수정했습니다.


<br>

## 📌 주요 집중 포인트
TestController 내 접근 권한 ROLE 테스트용 api 2개와 주석 참고하여 사용자 정보 가져와서 사용
어노테이션 사용 외에 시큐리티(SecurityContextHolder)에 직접 접근하여 가져올 수도 있으며 어떻게 써도 똑같습니다.


<br>

### 📎기타 사항
어려운 거 있으면 물어보셔유