### PR TITLE
[Rest Docs] json prettify

### DIFF
--- a/src/docs/asciidoc/Like-API.adoc
+++ b/src/docs/asciidoc/Like-API.adoc
@@ -21,4 +21,4 @@ operation::delete-like[snippets='http-request,request-headers,path-parameters,re
 
 === 사용자 좋아요 영상 목록 조회
 
-operation::get-liked-video-list[snippets='http-request,request-headers, response-fields-beneath-data-video-list, http-response']
+operation::get-liked-video-list[snippets='http-request,request-headers,response-fields-beneath-data-video-list,http-response']

--- a/src/docs/asciidoc/Video-API.adoc
+++ b/src/docs/asciidoc/Video-API.adoc
@@ -21,7 +21,7 @@ operation::get-video-detail-for-user[snippets='http-request,path-parameters,resp
 
 === 홈 영상 목록 조회 - 최신순
 
-operation::get-video-list-by-createdTime[snippets='http-request,request-parameters,response-fields-beneath-data,http-response']
+operation::get-video-list-by-created-time[snippets='http-request,request-parameters,response-fields-beneath-data,http-response']
 
 
 

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -569,7 +569,7 @@ Expires: 0
 X-Frame-Options: DENY
 Content-Length: 159
 
-{"timeStamp":"2023/07/16 22:19:53","code":"COMMON-200","message":"[공통] 정상 처리","data":"Pocket Pose API Server : Health check ok. Server is running"}</code></pre>
+{"timeStamp":"2023/07/16 23:33:31","code":"COMMON-200","message":"[공통] 정상 처리","data":"Pocket Pose API Server : Health check ok. Server is running"}</code></pre>
 </div>
 </div>
 </div>
@@ -587,11 +587,13 @@ Content-Length: 159
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/auth/login?type=kakao HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 33
-X-CSRF-TOKEN: 1af39072-d9b0-4b92-a261-533bba3dd2f3
+Content-Length: 41
+X-CSRF-TOKEN: 72f4497e-9174-4be9-af6b-9cb9492170d2
 Host: localhost:8080
 
-{"kakaoAccessToken":"dummyToken"}</code></pre>
+{
+  "kakaoAccessToken" : "dummyToken"
+}</code></pre>
 </div>
 </div>
 </div>
@@ -689,16 +691,19 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 228
+Content-Type: application/json;charset=UTF-8
+Content-Length: 282
 
-{"timeStamp":"2023/07/16 22:19:55","code":"USER-2000","message":"[사용자] 카카오 회원가입 및 로그인 성공","data":{"uuid":"43f0169a-6fcb-4625-8852-91ebf21d56e6","nickname":"nicknameTest","email":"test@email.com"}}</code></pre>
+{
+  "timeStamp" : "2023/07/16 23:33:32",
+  "code" : "USER-2000",
+  "message" : "[사용자] 카카오 회원가입 및 로그인 성공",
+  "data" : {
+    "uuid" : "6c605dad-7f3f-4f32-baae-71cf0867f1d3",
+    "nickname" : "nicknameTest",
+    "email" : "test@email.com"
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -717,7 +722,7 @@ Content-Length: 228
 <h4 id="_영상_상세_조회_비회원_http_request"><a class="link" href="#_영상_상세_조회_비회원_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/videos/anonymous/f8061ebd-b97a-42e2-aa8c-3345bb9c78d2 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/videos/anonymous/b9a7378a-3274-404b-85d3-bd396cac6bcc HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -852,16 +857,32 @@ Host: localhost:8080</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 520
+Content-Type: application/json;charset=UTF-8
+Content-Length: 684
 
-{"timeStamp":"2023/07/16 22:19:58","code":"VIDEO-2003","message":"VIDEO-동영상 상세 정보 조회 성공","data":{"uuid":"f8061ebd-b97a-42e2-aa8c-3345bb9c78d2","title":"타이틀 1","tag":"#해시 #태그 #1","user":{"uuid":"4f3c6b01-8d86-4205-a982-7328af5149cb","nickname":"닉네임","email":"이메일","profileImg":"프로필 이미지 s3 경로"},"videoUrl":"동영상 s3 경로 1","thumbnailUrl":"썸네일 이미지 s3 경로 1","likeCount":5,"commentCount":2,"length":9999,"createdTime":null,"liked":false}}</code></pre>
+{
+  "timeStamp" : "2023/07/16 23:33:34",
+  "code" : "VIDEO-2003",
+  "message" : "VIDEO-동영상 상세 정보 조회 성공",
+  "data" : {
+    "uuid" : "b9a7378a-3274-404b-85d3-bd396cac6bcc",
+    "title" : "타이틀 1",
+    "tag" : "#해시 #태그 #1",
+    "user" : {
+      "uuid" : "efc50686-7d7e-44f0-9347-067f63c3cb2c",
+      "nickname" : "닉네임",
+      "email" : "이메일",
+      "profileImg" : "프로필 이미지 s3 경로"
+    },
+    "videoUrl" : "동영상 s3 경로 1",
+    "thumbnailUrl" : "썸네일 이미지 s3 경로 1",
+    "likeCount" : 5,
+    "commentCount" : 2,
+    "length" : 9999,
+    "createdTime" : null,
+    "liked" : false
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -872,7 +893,7 @@ Content-Length: 520
 <h4 id="_영상_상세_조회_회원_http_request"><a class="link" href="#_영상_상세_조회_회원_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/videos/4c4ef32a-d7be-4003-97d3-1d2fa40a0337 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/videos/9d0d7f5e-f45a-4e66-9c1b-97acbdd43467 HTTP/1.1
 headerXAccessToken: headerXAccessToken
 headerXRefreshToken: headerXRefreshToken
 Host: localhost:8080</code></pre>
@@ -1009,16 +1030,32 @@ Host: localhost:8080</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 514
+Content-Type: application/json;charset=UTF-8
+Content-Length: 678
 
-{"timeStamp":"2023/07/16 22:19:58","code":"VIDEO-2003","message":"VIDEO-동영상 상세 정보 조회 성공","data":{"uuid":"4c4ef32a-d7be-4003-97d3-1d2fa40a0337","title":"타이틀","tag":"#해시 #태그","user":{"uuid":"ebfc82d9-6f21-4e93-841e-c9c28daaa7f0","nickname":"닉네임","email":"이메일","profileImg":"프로필 이미지 s3 경로"},"videoUrl":"동영상 s3 경로","thumbnailUrl":"썸네일 이미지 s3 경로","likeCount":3,"commentCount":11,"length":107800,"createdTime":null,"liked":false}}</code></pre>
+{
+  "timeStamp" : "2023/07/16 23:33:34",
+  "code" : "VIDEO-2003",
+  "message" : "VIDEO-동영상 상세 정보 조회 성공",
+  "data" : {
+    "uuid" : "9d0d7f5e-f45a-4e66-9c1b-97acbdd43467",
+    "title" : "타이틀",
+    "tag" : "#해시 #태그",
+    "user" : {
+      "uuid" : "da7b490b-2db9-4796-95e2-c369e48b4f98",
+      "nickname" : "닉네임",
+      "email" : "이메일",
+      "profileImg" : "프로필 이미지 s3 경로"
+    },
+    "videoUrl" : "동영상 s3 경로",
+    "thumbnailUrl" : "썸네일 이미지 s3 경로",
+    "likeCount" : 3,
+    "commentCount" : 11,
+    "length" : 107800,
+    "createdTime" : null,
+    "liked" : false
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1169,16 +1206,52 @@ Host: localhost:8080</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 946
+Content-Type: application/json;charset=UTF-8
+Content-Length: 1339
 
-{"timeStamp":"2023/07/16 22:19:58","code":"VIDEO-2004","message":"VIDEO-동영상 목록 정보 조회 성공","data":{"videoList":[{"uuid":"5f4c3288-94b0-4fc5-86c0-822ae27c0066","title":"타이틀","tag":"#해시 #태그","user":{"uuid":"58ab1003-5f23-45d3-8a95-8dd6f99ccc95","nickname":"닉네임","email":"이메일","profileImg":"프로필 이미지 s3 경로"},"videoUrl":"동영상 s3 경로","thumbnailUrl":"썸네일 이미지 s3 경로","likeCount":3,"commentCount":11,"length":107800,"createdTime":null,"liked":false},{"uuid":"b898a7aa-33ba-417a-afdd-831ef7cad183","title":"타이틀 1","tag":"#해시 #태그 #1","user":{"uuid":"58ab1003-5f23-45d3-8a95-8dd6f99ccc95","nickname":"닉네임","email":"이메일","profileImg":"프로필 이미지 s3 경로"},"videoUrl":"동영상 s3 경로 1","thumbnailUrl":"썸네일 이미지 s3 경로 1","likeCount":5,"commentCount":2,"length":9999,"createdTime":null,"liked":false}],"isLast":true}}</code></pre>
+{
+  "timeStamp" : "2023/07/16 23:33:34",
+  "code" : "VIDEO-2004",
+  "message" : "VIDEO-동영상 목록 정보 조회 성공",
+  "data" : {
+    "videoList" : [ {
+      "uuid" : "32c55951-6c31-495b-99f4-4ae180b7bc5b",
+      "title" : "타이틀",
+      "tag" : "#해시 #태그",
+      "user" : {
+        "uuid" : "971859e5-2a25-4749-936d-a86f840ef438",
+        "nickname" : "닉네임",
+        "email" : "이메일",
+        "profileImg" : "프로필 이미지 s3 경로"
+      },
+      "videoUrl" : "동영상 s3 경로",
+      "thumbnailUrl" : "썸네일 이미지 s3 경로",
+      "likeCount" : 3,
+      "commentCount" : 11,
+      "length" : 107800,
+      "createdTime" : null,
+      "liked" : false
+    }, {
+      "uuid" : "f3789649-731e-408f-90c0-45b5e2f910ef",
+      "title" : "타이틀 1",
+      "tag" : "#해시 #태그 #1",
+      "user" : {
+        "uuid" : "971859e5-2a25-4749-936d-a86f840ef438",
+        "nickname" : "닉네임",
+        "email" : "이메일",
+        "profileImg" : "프로필 이미지 s3 경로"
+      },
+      "videoUrl" : "동영상 s3 경로 1",
+      "thumbnailUrl" : "썸네일 이미지 s3 경로 1",
+      "likeCount" : 5,
+      "commentCount" : 2,
+      "length" : 9999,
+      "createdTime" : null,
+      "liked" : false
+    } ],
+    "isLast" : true
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1329,16 +1402,52 @@ Host: localhost:8080</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 946
+Content-Type: application/json;charset=UTF-8
+Content-Length: 1339
 
-{"timeStamp":"2023/07/16 22:19:58","code":"VIDEO-2004","message":"VIDEO-동영상 목록 정보 조회 성공","data":{"videoList":[{"uuid":"8c18b14a-a4e1-4bd1-ab1f-e122e8732832","title":"타이틀","tag":"#해시 #태그","user":{"uuid":"68372fe6-65c8-4d94-93ac-3ec12569fba1","nickname":"닉네임","email":"이메일","profileImg":"프로필 이미지 s3 경로"},"videoUrl":"동영상 s3 경로","thumbnailUrl":"썸네일 이미지 s3 경로","likeCount":3,"commentCount":11,"length":107800,"createdTime":null,"liked":false},{"uuid":"d39b65bb-83b6-4168-b1f5-6384f3b34ed5","title":"타이틀 1","tag":"#해시 #태그 #1","user":{"uuid":"68372fe6-65c8-4d94-93ac-3ec12569fba1","nickname":"닉네임","email":"이메일","profileImg":"프로필 이미지 s3 경로"},"videoUrl":"동영상 s3 경로 1","thumbnailUrl":"썸네일 이미지 s3 경로 1","likeCount":5,"commentCount":2,"length":9999,"createdTime":null,"liked":false}],"isLast":true}}</code></pre>
+{
+  "timeStamp" : "2023/07/16 23:33:34",
+  "code" : "VIDEO-2004",
+  "message" : "VIDEO-동영상 목록 정보 조회 성공",
+  "data" : {
+    "videoList" : [ {
+      "uuid" : "e13c419d-f1a6-47d6-aaf3-2c412c18a0f4",
+      "title" : "타이틀",
+      "tag" : "#해시 #태그",
+      "user" : {
+        "uuid" : "8fb300ca-beb1-4060-8848-e3f77b1f89a8",
+        "nickname" : "닉네임",
+        "email" : "이메일",
+        "profileImg" : "프로필 이미지 s3 경로"
+      },
+      "videoUrl" : "동영상 s3 경로",
+      "thumbnailUrl" : "썸네일 이미지 s3 경로",
+      "likeCount" : 3,
+      "commentCount" : 11,
+      "length" : 107800,
+      "createdTime" : null,
+      "liked" : false
+    }, {
+      "uuid" : "e669560f-5c08-493c-a73c-a61c82f96319",
+      "title" : "타이틀 1",
+      "tag" : "#해시 #태그 #1",
+      "user" : {
+        "uuid" : "8fb300ca-beb1-4060-8848-e3f77b1f89a8",
+        "nickname" : "닉네임",
+        "email" : "이메일",
+        "profileImg" : "프로필 이미지 s3 경로"
+      },
+      "videoUrl" : "동영상 s3 경로 1",
+      "thumbnailUrl" : "썸네일 이미지 s3 경로 1",
+      "likeCount" : 5,
+      "commentCount" : 2,
+      "length" : 9999,
+      "createdTime" : null,
+      "liked" : false
+    } ],
+    "isLast" : true
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1349,7 +1458,7 @@ Content-Length: 946
 <h4 id="_영상_삭제_http_request"><a class="link" href="#_영상_삭제_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/videos/8525b619-8bae-4dd4-9154-b87f7e58de2e?_csrf=8552c62d-91ae-4d97-b16d-2681c24208a2 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/videos/eed153ba-0350-4e63-81c9-389d170f9cef?_csrf=2821cf45-42a1-48e5-a8c0-30f161278b15 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1406,16 +1515,17 @@ Host: localhost:8080</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 121
+Content-Type: application/json;charset=UTF-8
+Content-Length: 159
 
-{"timeStamp":"2023/07/16 22:19:58","code":"VIDEO-2002","message":"VIDEO-동영상 삭제 성공","data":{"success":true}}</code></pre>
+{
+  "timeStamp" : "2023/07/16 23:33:34",
+  "code" : "VIDEO-2002",
+  "message" : "VIDEO-동영상 삭제 성공",
+  "data" : {
+    "success" : true
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1444,7 +1554,7 @@ Content-Disposition: form-data; name=tag
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=_csrf
 
-afa5cbf0-9ca9-4ba8-bde6-4c509bce1b93
+d08b6b12-dbf7-43cf-a38d-ec47af728027
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=video; filename=video
 Content-Type: application/json
@@ -1536,16 +1646,17 @@ videoFile
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 155
+Content-Type: application/json;charset=UTF-8
+Content-Length: 193
 
-{"timeStamp":"2023/07/16 22:19:58","code":"VIDEO-2001","message":"VIDEO-동영상 업로드 성공","data":{"uuid":"e6ac9e5b-1153-4626-aa57-44e315f8035d"}}</code></pre>
+{
+  "timeStamp" : "2023/07/16 23:33:33",
+  "code" : "VIDEO-2001",
+  "message" : "VIDEO-동영상 업로드 성공",
+  "data" : {
+    "uuid" : "99a6ac8e-b1a5-465a-81bb-70548c510a62"
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1714,15 +1825,17 @@ Content-Length: 935
 <h4 id="_댓글_등록_http_request"><a class="link" href="#_댓글_등록_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/comments/d0a3d063-e564-43a8-801d-d5261122773f?_csrf=24834022-7b21-430b-a598-381a47c57fab HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/comments/02de105f-7c3d-41bc-a2a2-a691228be611?_csrf=7baeba94-ce1f-4eb0-93fb-bcb1322d9dca HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 headerXAccessToken: headerXAccessToken
 headerXRefreshToken: headerXRefreshToken
 Accept: application/json
-Content-Length: 40
+Content-Length: 48
 Host: localhost:8080
 
-{"content":"댓글을 작성했어요!"}</code></pre>
+{
+  "content" : "댓글을 작성했어요!"
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1755,7 +1868,9 @@ Host: localhost:8080
 <h4 id="_댓글_등록_request_body"><a class="link" href="#_댓글_등록_request_body">Request body</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"content":"댓글을 작성했어요!"}</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
+  "content" : "댓글을 작성했어요!"
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1819,16 +1934,24 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 331
+Content-Type: application/json;charset=UTF-8
+Content-Length: 431
 
-{"timeStamp":"2023/07/16 22:19:56","code":"VIDEO-2020","message":"VIDEO-댓글 등록 성공","data":{"uuid":"f6cca0b3-0bd4-4b13-b0f1-74f122b0966e","content":"댓글을 작성했어요!","user":{"uuid":"9f407b6a-bbc0-4d17-914a-1eaba6a56e10","nickname":"닉네임","email":"이메일","profileImg":"프로필 이미지 s3 경로"}}}</code></pre>
+{
+  "timeStamp" : "2023/07/16 23:33:32",
+  "code" : "VIDEO-2020",
+  "message" : "VIDEO-댓글 등록 성공",
+  "data" : {
+    "uuid" : "48d3fb3e-9af6-4603-b0b8-b5160d912d44",
+    "content" : "댓글을 작성했어요!",
+    "user" : {
+      "uuid" : "957346a6-c56c-4f26-a11d-69db6faef9e6",
+      "nickname" : "닉네임",
+      "email" : "이메일",
+      "profileImg" : "프로필 이미지 s3 경로"
+    }
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1839,7 +1962,7 @@ Content-Length: 331
 <h4 id="_댓글_삭제_http_request"><a class="link" href="#_댓글_삭제_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/comments/927801af-205f-4159-8e58-822eca369a76?_csrf=f0a869d7-4e2c-4f0e-bedc-6300d53f8c61 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/comments/f9bfc436-3b8c-491e-9bbd-f6ab8165dd08?_csrf=94b98b75-ae75-46b1-ab6d-84dd34102e97 HTTP/1.1
 headerXAccessToken: headerXAccessToken
 headerXRefreshToken: headerXRefreshToken
 Host: localhost:8080</code></pre>
@@ -1923,16 +2046,17 @@ Host: localhost:8080</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 118
+Content-Type: application/json;charset=UTF-8
+Content-Length: 156
 
-{"timeStamp":"2023/07/16 22:19:56","code":"VIDEO-2021","message":"VIDEO-댓글 삭제 성공","data":{"success":true}}</code></pre>
+{
+  "timeStamp" : "2023/07/16 23:33:32",
+  "code" : "VIDEO-2021",
+  "message" : "VIDEO-댓글 삭제 성공",
+  "data" : {
+    "success" : true
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1943,7 +2067,7 @@ Content-Length: 118
 <h4 id="_동영상의_댓글_목록_조회_http_request"><a class="link" href="#_동영상의_댓글_목록_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/comments/08e3678b-f3b5-43b9-bdfe-d137544e7277 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/comments/f4fc76c8-3b8b-4db2-a33a-7f8a15e86137 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2020,16 +2144,37 @@ Host: localhost:8080</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 631
+Content-Type: application/json;charset=UTF-8
+Content-Length: 876
 
-{"timeStamp":"2023/07/16 22:19:56","code":"VIDEO-2022","message":"VIDEO-댓글 목록 조회 성공","data":{"commentList":[{"uuid":"8d5a1b2e-0d3d-4701-98b2-fe559ef11eda","content":"댓글을 작성했어요!","user":{"uuid":"89b3c119-3822-485d-9f62-81a1fe0d2a6b","nickname":"닉네임","email":"이메일","profileImg":"프로필 이미지 s3 경로"},"createdTime":null},{"uuid":"d723ad18-d2c8-4a88-b528-8be9cd35fde4","content":"또 다른 댓글을 썼습니다","user":{"uuid":"89b3c119-3822-485d-9f62-81a1fe0d2a6b","nickname":"닉네임","email":"이메일","profileImg":"프로필 이미지 s3 경로"},"createdTime":null}]}}</code></pre>
+{
+  "timeStamp" : "2023/07/16 23:33:32",
+  "code" : "VIDEO-2022",
+  "message" : "VIDEO-댓글 목록 조회 성공",
+  "data" : {
+    "commentList" : [ {
+      "uuid" : "7f17cd51-66ba-4078-aff9-15c9d173bde0",
+      "content" : "댓글을 작성했어요!",
+      "user" : {
+        "uuid" : "555b819f-cb83-4372-9dba-b4f6ee5c86a9",
+        "nickname" : "닉네임",
+        "email" : "이메일",
+        "profileImg" : "프로필 이미지 s3 경로"
+      },
+      "createdTime" : null
+    }, {
+      "uuid" : "a9bdad21-682c-4ef2-ab06-ece20ab5b62e",
+      "content" : "또 다른 댓글을 썼습니다",
+      "user" : {
+        "uuid" : "555b819f-cb83-4372-9dba-b4f6ee5c86a9",
+        "nickname" : "닉네임",
+        "email" : "이메일",
+        "profileImg" : "프로필 이미지 s3 경로"
+      },
+      "createdTime" : null
+    } ]
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -2049,13 +2194,13 @@ Content-Length: 631
 <h4 id="_좋아요_등록_http_request"><a class="link" href="#_좋아요_등록_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/likes/3da35704-2076-4160-8a60-15f64f4a87ef HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/likes/8552c42e-5fcc-42f3-919c-ff721be3207c HTTP/1.1
 headerXAccessToken: headerXAccessToken
 headerXRefreshToken: headerXRefreshToken
 Host: localhost:8080
 Content-Type: application/x-www-form-urlencoded
 
-_csrf=d5a80c4f-9ac8-4e2f-ac72-a2421342185f</code></pre>
+_csrf=65485fe7-2d33-41db-9c44-0d6dfd830745</code></pre>
 </div>
 </div>
 </div>
@@ -2136,16 +2281,17 @@ _csrf=d5a80c4f-9ac8-4e2f-ac72-a2421342185f</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 121
+Content-Type: application/json;charset=UTF-8
+Content-Length: 159
 
-{"timeStamp":"2023/07/16 22:19:57","code":"VIDEO-2030","message":"VIDEO-좋아요 등록 성공","data":{"success":true}}</code></pre>
+{
+  "timeStamp" : "2023/07/16 23:33:33",
+  "code" : "VIDEO-2030",
+  "message" : "VIDEO-좋아요 등록 성공",
+  "data" : {
+    "success" : true
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -2156,7 +2302,7 @@ Content-Length: 121
 <h4 id="_좋아요_삭제_http_request"><a class="link" href="#_좋아요_삭제_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/likes/94a99cc4-48c8-4b8a-a0c8-99efdf96852a?_csrf=01658a9c-ce0f-4eb1-9aa9-9fe054ae20ca HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/likes/aa442e7c-ba52-4fd0-8994-e1292df76cdd?_csrf=9b21ff14-a98e-451a-8ca2-36d80f42e49e HTTP/1.1
 headerXAccessToken: headerXAccessToken
 headerXRefreshToken: headerXRefreshToken
 Host: localhost:8080</code></pre>
@@ -2240,16 +2386,17 @@ Host: localhost:8080</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 121
+Content-Type: application/json;charset=UTF-8
+Content-Length: 159
 
-{"timeStamp":"2023/07/16 22:19:57","code":"VIDEO-2031","message":"VIDEO-좋아요 삭제 성공","data":{"success":true}}</code></pre>
+{
+  "timeStamp" : "2023/07/16 23:33:33",
+  "code" : "VIDEO-2031",
+  "message" : "VIDEO-좋아요 삭제 성공",
+  "data" : {
+    "success" : true
+  }
+}</code></pre>
 </div>
 </div>
 </div>
@@ -2291,19 +2438,156 @@ Host: localhost:8080</code></pre>
 </tr>
 </tbody>
 </table>
-<div class="paragraph">
-<p>[[<em>사용자_좋아요_영상_목록_조회</em> response_fields-beneath-data-video-list]]
-==  response fields-beneath-data-video-list</p>
 </div>
-<div class="paragraph">
-<p>Snippet  response-fields-beneath-data-video-list not found for operation::get-liked-video-list</p>
+<div class="sect3">
+<h4 id="_사용자_좋아요_영상_목록_조회_response_fields-beneath-data-video-list"><a class="link" href="#_사용자_좋아요_영상_목록_조회_response_fields-beneath-data-video-list">Response fields-beneath-data-video-list</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필드명</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">타입</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필수여부</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>uuid</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동영상 식별자 UUID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">영상 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>tag</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">해시태그</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>user.uuid</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성 사용자 식별자 uuid</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>user.email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 이메일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>user.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>user.profileImg</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사용자 프로필 사진 S3 경로</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>videoUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">동영상 S3 경로</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>thumbnailUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">썸네일 이미지 S3 경로</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>commentCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>length</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">milliseconds 단위 동영상 길이</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>DateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성 시각</p></td>
+</tr>
+</tbody>
+</table>
 </div>
-<div class="paragraph">
-<p>[[<em>사용자_좋아요_영상_목록_조회</em> http_response]]
-==  http response</p>
+<div class="sect3">
+<h4 id="_사용자_좋아요_영상_목록_조회_http_response"><a class="link" href="#_사용자_좋아요_영상_목록_조회_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 1346
+
+{
+  "timeStamp" : "2023/07/16 23:33:33",
+  "code" : "VIDEO-2032",
+  "message" : "VIDEO-좋아요 누른 영상 목록 조회 성공",
+  "data" : {
+    "videoList" : [ {
+      "uuid" : "73af0c88-37cd-4b34-9255-5b3079a1dc48",
+      "title" : "타이틀",
+      "tag" : "#해시 #태그",
+      "user" : {
+        "uuid" : "55365f65-708e-49b0-9e09-7e8ac7b6d132",
+        "nickname" : "닉네임",
+        "email" : "이메일",
+        "profileImg" : "프로필 이미지 s3 경로"
+      },
+      "videoUrl" : "동영상 s3 경로",
+      "thumbnailUrl" : "썸네일 이미지 s3 경로",
+      "likeCount" : 3,
+      "commentCount" : 11,
+      "length" : 107800,
+      "createdTime" : null,
+      "liked" : false
+    }, {
+      "uuid" : "e5c8c30f-2a44-4f81-9915-b3e8a11b619d",
+      "title" : "타이틀 1",
+      "tag" : "#해시 #태그 #1",
+      "user" : {
+        "uuid" : "55365f65-708e-49b0-9e09-7e8ac7b6d132",
+        "nickname" : "닉네임",
+        "email" : "이메일",
+        "profileImg" : "프로필 이미지 s3 경로"
+      },
+      "videoUrl" : "동영상 s3 경로 1",
+      "thumbnailUrl" : "썸네일 이미지 s3 경로 1",
+      "likeCount" : 5,
+      "commentCount" : 2,
+      "length" : 9999,
+      "createdTime" : null,
+      "liked" : false
+    } ],
+    "isLast" : null
+  }
+}</code></pre>
 </div>
-<div class="paragraph">
-<p>Snippet  http-response not found for operation::get-liked-video-list</p>
 </div>
 </div>
 <hr>

--- a/src/test/java/hatch/hatchserver2023/global/config/restdocs/RestDocsConfig.java
+++ b/src/test/java/hatch/hatchserver2023/global/config/restdocs/RestDocsConfig.java
@@ -1,10 +1,25 @@
 package hatch.hatchserver2023.global.config.restdocs;
 
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
 import org.springframework.restdocs.snippet.Attributes.Attribute;
 
 @TestConfiguration
 public class RestDocsConfig {
+
+    //한글 깨짐 해결 & json 예쁘게 출력
+    @Bean
+    public RestDocumentationResultHandler handler() {
+        return MockMvcRestDocumentation.document(
+                "{method-name}",
+                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+        );
+    }
+
     public static final Attribute parameter (
             final String key,
             final String value){


### PR DESCRIPTION
🏷️ Jira issue : HH-253

― PR 유형 ―
- 명세서 코드 수정


<br>

## 📑 작업 내용 
한글 깨짐 이슈와 Json Prettify 이슈를 수정했습니다.
참고한 블로그 링크는 [여기](https://velog.io/@ililil9482/Restdocs-%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0
) 있습니다.

수정한 부분은 각 `ControllerTest` 코드들과 `RestDocsConfig.java` 입니다.


가장 큰 변경사항

- `.andDo(document())` -> `andDo(docs.document())` 부분으로 직접 설정한 docs를 통해 문서를 작성하며, snippet 이름을 직접 설정할 필요 없이 method이름을 자동으로 사용합니다.



<br>

## 📌 주요 집중 포인트
결과적으로, snippet `response body의 json`은 아래와 같이 보기 좋게 prettify 되었습니다.
![image](https://github.com/2023-HATCH/hatch-server-2023/assets/81364415/02314f75-3d77-4e3a-98a6-286014529297)


<br>

## 🔥 어려웠던 부분 & 트러블 슈팅



<br>

## 🐣 앞으로 할 일



<br>

## 📎기타 사항
제안 사항이므로 의견 부탁드립니다.
