### PR TITLE
Feature/talk 라이브톡 api 들 생성 (HH-195~199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# hatch-server-2023
+본 프로젝트 서버
+---
+
+- 백엔드 컨벤션 모음 [페이지](https://www.notion.so/f72a464effac43b0833517d833d10b07?v=d8ddceb7db234959818cd47e8fe332b3)

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 //	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' 	//s3
 	implementation 'io.jsonwebtoken:jjwt:0.9.1' //jwt
 	implementation 'com.google.code.gson:gson:2.10.1' //gson
+	implementation 'org.springframework.boot:spring-boot-starter-websocket' //web socket
+	implementation 'org.springframework.security:spring-security-messaging' //security for web socket
 
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
   

--- a/src/docs/asciidoc/StatusCode.adoc
+++ b/src/docs/asciidoc/StatusCode.adoc
@@ -4,6 +4,8 @@ include::{snippets}/status-code/code-response-fields-COMMON.adoc[]
 
 include::{snippets}/status-code/code-response-fields-USER.adoc[]
 
+include::{snippets}/status-code/code-response-fields-TALK.adoc[]
+
 //opertation 쓰면 스니펫 여러개 한번에 넣어줄 수 있지만, 같이 들어가는 자동 헤더를 못지우겠음
 // operation::status-code[snippets='code-response-fields-beneath-status_codes']
 // :operation-code-response-fields-beneath-status_codes-title: hihi

--- a/src/docs/asciidoc/Talk-API.adoc
+++ b/src/docs/asciidoc/Talk-API.adoc
@@ -1,0 +1,9 @@
+// 도메인 명 : h1
+= Talk
+
+// api 명 : h3
+=== *Get Talk Messages*
+라이브톡 메세지 목록 조회(최신순) api
+
+operation::get-talk-messages[snippets='http-request,request-parameters,response-fields-beneath-data,http-response']
+

--- a/src/docs/asciidoc/Talk-SOCKET.adoc
+++ b/src/docs/asciidoc/Talk-SOCKET.adoc
@@ -1,0 +1,9 @@
+// 도메인 명 : h1
+= Talk (Web Socket)
+
+// 수동으로 작성
+include::talk-socket/talk-message-send.adoc[]
+
+// 수동으로 작성
+include::talk-socket/talk-reaction-send.adoc[]
+

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -12,8 +12,8 @@ include::User-API.adoc[]
 '''
 include::Video-API.adoc[]
 '''
-
-
+include::Talk-API.adoc[]
+'''
 include::Talk-SOCKET.adoc[]
 '''
 

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -11,6 +11,9 @@ include::HealthCheck-API.adoc[]
 include::User-API.adoc[]
 '''
 
+include::Talk-SOCKET.adoc[]
+'''
+
 // 도메인 명 : h1
 = Status Code
 

--- a/src/docs/asciidoc/talk-socket/talk-message-send.adoc
+++ b/src/docs/asciidoc/talk-socket/talk-message-send.adoc
@@ -1,0 +1,63 @@
+
+// api 명 : h3
+=== *Talk Message Send*
+라이브톡 메세지 전송
+
+==== Request header
+|===
+|필드명|타입|필수여부|제약조건|설명
+|`+x-access-token+`
+|`+String+`
+|true
+|JWT 형식
+|액세스 토큰
+|===
+
+==== Request fields
+[source,options="nowrap"]
+----
+{"content":"안녕하세요~"}
+----
+// === Request fields
+|===
+|필드명|타입|필수여부|제약조건|설명
+|`+content+`
+|`+String+`
+|true
+|공백 불가
+|전송 메세지 내용
+|===
+
+
+==== Response body
+|===
+|필드명|타입|필수여부|설명
+|`+createdAt+`
+|`+LocalDateTime(String)+`
+|true
+|보낸 시각
+|`+content+`
+|`+String+`
+|true
+|메세지 내용
+|`+type+`
+|`+String+`
+|true
+|응답 타입(고정값 : message). 이 응답이 다른 사람의 메세지 전송을 전달하는 응답이라는 뜻
+|`+sender+`
+|`+String+`
+|true
+|보낸 사용자 정보
+|`+userId+`
+|`+String+`
+|true
+|보낸 사용자 고유값
+|`+nickname+`
+|`+String+`
+|true
+|보낸 사용자 닉네임
+|`+profileImg+`
+|`+String+`
+|true
+|보낸 사용자 프로필 사진
+|===

--- a/src/docs/asciidoc/talk-socket/talk-message-send.adoc
+++ b/src/docs/asciidoc/talk-socket/talk-message-send.adoc
@@ -1,6 +1,6 @@
 
 // api 명 : h3
-=== *Talk Message Send*
+=== *Send Talk Message*
 라이브톡 메세지 전송
 
 ==== Request header

--- a/src/docs/asciidoc/talk-socket/talk-reaction-send.adoc
+++ b/src/docs/asciidoc/talk-socket/talk-reaction-send.adoc
@@ -1,5 +1,5 @@
 // api 명 : h3
-=== *Talk Reaction Send*
+=== *Send Talk Reaction*
 라이브톡 반응 전송
 
 ==== Request header

--- a/src/docs/asciidoc/talk-socket/talk-reaction-send.adoc
+++ b/src/docs/asciidoc/talk-socket/talk-reaction-send.adoc
@@ -1,0 +1,32 @@
+// api 명 : h3
+=== *Talk Reaction Send*
+라이브톡 반응 전송
+
+==== Request header
+|===
+|필드명|타입|필수여부|제약조건|설명
+|`+x-access-token+`
+|`+String+`
+|true
+|JWT 형식
+|액세스 토큰
+|===
+
+
+==== Response body
+|===
+|필드명|타입|필수여부|설명
+|`+createdAt+`
+|`+LocalDateTime(String)+`
+|true
+|보낸 시각
+|`+content+`
+|`+String+`
+|true
+|메세지 내용
+|`+type+`
+|`+String+`
+|true
+|응답 타입(고정값 : reaction). 이 응답이 다른 사람의 반응 전송을 전달하는 응답이라는 뜻
+|===
+

--- a/src/main/java/hatch/hatchserver2023/domain/talk/api/TalkController.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/api/TalkController.java
@@ -1,0 +1,47 @@
+package hatch.hatchserver2023.domain.talk.api;
+
+import hatch.hatchserver2023.domain.talk.application.TalkService;
+import hatch.hatchserver2023.domain.talk.domain.TalkMessage;
+import hatch.hatchserver2023.domain.talk.dto.TalkResponseDto;
+import hatch.hatchserver2023.global.common.response.CommonResponse;
+import hatch.hatchserver2023.global.common.response.code.TalkStatusCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Slf4j
+@Validated
+@RestController
+@RequestMapping("/api/v1/talks")
+public class TalkController {
+
+    private final TalkService talkService;
+
+    public TalkController(TalkService talkService) {
+        this.talkService = talkService;
+    }
+
+    /**
+     * 스테이지 라이브톡 메세지 조회 api (최근순)
+     * @param page
+     * @param size
+     * @return
+     */
+    @GetMapping("/messages")
+    public ResponseEntity<CommonResponse> getTalkMessages(@RequestParam @NotNull @Min(0) Integer page,
+                                                             @RequestParam @NotNull Integer size) {
+        Pageable pageRequest = PageRequest.of(page, size, Sort.by("createdTime").descending());
+        Slice<TalkMessage> talkMessages = talkService.getTalkMessages(pageRequest);
+        return ResponseEntity.ok().body(CommonResponse.toResponse(
+                TalkStatusCode.GET_TALK_MESSAGES_SUCCESS, TalkResponseDto.GetMessagesContainer.toDto(talkMessages)));
+    }
+}

--- a/src/main/java/hatch/hatchserver2023/domain/talk/api/TalkController.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/api/TalkController.java
@@ -1,0 +1,85 @@
+package hatch.hatchserver2023.domain.talk.api;
+
+import hatch.hatchserver2023.domain.talk.application.TalkService;
+import hatch.hatchserver2023.domain.talk.domain.TalkMessage;
+import hatch.hatchserver2023.domain.talk.dto.TalkRequestDto;
+import hatch.hatchserver2023.domain.talk.dto.TalkResponseDto;
+import hatch.hatchserver2023.domain.user.domain.User;
+import hatch.hatchserver2023.domain.user.dto.UserResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Controller
+public class TalkController {
+    private final String TYPE_TALK_MESSAGE = "message";
+    private final String TYPE_TALK_REACTION = "reaction";
+
+    private final TalkService talkService;
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
+    public TalkController(TalkService talkService, SimpMessagingTemplate simpMessagingTemplate) {
+        this.talkService = talkService;
+        this.simpMessagingTemplate = simpMessagingTemplate;
+    }
+
+    /**
+     * 스테이지 라이브톡 메세지 전송 메서드
+     * @param requestDto
+     * @param sender : 메세지 전송자
+     */
+    @MessageMapping("/talks/messages")
+    public void sendTalkMessage(TalkRequestDto.SendMessage requestDto, @AuthenticationPrincipal User sender) { //Message message,
+        log.info("[WS] /app/talks/messages");
+        //주석 로그
+/*        log.info("[WS] message : {}", message);
+        log.info("requestDto : {}", requestDto);
+
+        //유저 인증정보 받아오는 거 setUser만 하면 getUser(simpUser), @AuthenticationPrincipal, SecurityContextHolder 셋 다 잘 됨!
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        UsernamePasswordAuthenticationToken userToken = (UsernamePasswordAuthenticationToken) accessor.getUser();
+        log.info("[WS] sendTalkMessage userToken : {}", userToken);
+        User simpUser = (User) userToken.getPrincipal();
+        log.info("simpUser nickname : {}", simpUser.getNickname());
+        log.info("SecurityContextHolder principal : {}", SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+        */
+        log.info("@AuthenticationPrincipal user : {}", sender.getNickname());
+
+        // DB 저장
+        TalkMessage savedTalkMessage = talkService.saveTalkMessage(requestDto.toEntity(), sender);
+
+        TalkResponseDto.SendMessage responseDto = TalkResponseDto.SendMessage.builder()
+                .type(TYPE_TALK_MESSAGE)
+                .content(savedTalkMessage.getContent())
+                .createdAt(savedTalkMessage.getCreatedTime().toString())
+                .sender(UserResponseDto.SimpleUserProfile.toDto(sender))
+                .build();
+
+        simpMessagingTemplate.convertAndSend("/topic/stage", responseDto);
+    }
+
+    /**
+     * 스테이지 라이브반응 전송 메서드
+     */
+    @MessageMapping("/talks/reactions")
+    public void sendTalkReaction() {
+        TalkResponseDto.SendReaction responseDto = TalkResponseDto.SendReaction.builder()
+                .type(TYPE_TALK_REACTION)
+                .createdAt(LocalDateTime.now().toString())
+                .build();
+
+        simpMessagingTemplate.convertAndSend("/topic/stage", responseDto);
+    }
+
+}

--- a/src/main/java/hatch/hatchserver2023/domain/talk/api/TalkController.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/api/TalkController.java
@@ -8,6 +8,7 @@ import hatch.hatchserver2023.global.common.response.code.TalkStatusCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,11 +37,11 @@ public class TalkController {
      * @param size
      * @return
      */
+    @PreAuthorize("hasAnyRole('ROLE_USER')")
     @GetMapping("/messages")
     public ResponseEntity<CommonResponse> getTalkMessages(@RequestParam @NotNull @Min(0) Integer page,
                                                              @RequestParam @NotNull Integer size) {
-        Pageable pageRequest = PageRequest.of(page, size, Sort.by("createdAt").descending()); //service 로?
-        Slice<TalkMessage> talkMessages = talkService.getTalkMessages(pageRequest);
+        Slice<TalkMessage> talkMessages = talkService.getTalkMessages(page, size);
         return ResponseEntity.ok().body(CommonResponse.toResponse(
                 TalkStatusCode.GET_TALK_MESSAGES_SUCCESS, TalkResponseDto.GetMessagesContainer.toDto(talkMessages)));
     }

--- a/src/main/java/hatch/hatchserver2023/domain/talk/api/TalkController.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/api/TalkController.java
@@ -12,11 +12,14 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import java.security.Principal;
 import java.time.LocalDateTime;
 
@@ -35,14 +38,15 @@ public class TalkController {
     }
 
     /**
-     * 스테이지 라이브톡 메세지 전송 메서드
+     * 스테이지 라이브톡 메세지 전송 api (ws)
      * @param requestDto
      * @param sender : 메세지 전송자
      */
     @MessageMapping("/talks/messages")
-    public void sendTalkMessage(TalkRequestDto.SendMessage requestDto, @AuthenticationPrincipal User sender) { //Message message,
+//    @PreAuthorize("hasAnyRole('ROLE_USER')") //어차피 securityConfig 단에서부터 막혀서 여기다 설정할 필요 없음
+    public void sendTalkMessage(@Valid TalkRequestDto.SendMessage requestDto, @AuthenticationPrincipal @NotNull User sender) { //Message message,
         log.info("[WS] /app/talks/messages");
-        //주석 로그
+        //확인용 로그들 주석
 /*        log.info("[WS] message : {}", message);
         log.info("requestDto : {}", requestDto);
 
@@ -53,7 +57,7 @@ public class TalkController {
         User simpUser = (User) userToken.getPrincipal();
         log.info("simpUser nickname : {}", simpUser.getNickname());
         log.info("SecurityContextHolder principal : {}", SecurityContextHolder.getContext().getAuthentication().getPrincipal());
-        */
+*/
         log.info("@AuthenticationPrincipal user : {}", sender.getNickname());
 
         // DB 저장
@@ -70,10 +74,12 @@ public class TalkController {
     }
 
     /**
-     * 스테이지 라이브반응 전송 메서드
+     * 스테이지 라이브반응 전송 api (ws)
      */
     @MessageMapping("/talks/reactions")
     public void sendTalkReaction() {
+        log.info("[WS] /app/talks/reactions");
+
         TalkResponseDto.SendReaction responseDto = TalkResponseDto.SendReaction.builder()
                 .type(TYPE_TALK_REACTION)
                 .createdAt(LocalDateTime.now().toString())

--- a/src/main/java/hatch/hatchserver2023/domain/talk/api/TalkWebSocketController.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/api/TalkWebSocketController.java
@@ -7,32 +7,25 @@ import hatch.hatchserver2023.domain.talk.dto.TalkResponseDto;
 import hatch.hatchserver2023.domain.user.domain.User;
 import hatch.hatchserver2023.domain.user.dto.UserResponseDto;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
-import org.springframework.messaging.support.MessageHeaderAccessor;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.security.Principal;
 import java.time.LocalDateTime;
 
 @Slf4j
 @Controller
-public class TalkController {
+public class TalkWebSocketController {
     private final String TYPE_TALK_MESSAGE = "message";
     private final String TYPE_TALK_REACTION = "reaction";
 
     private final TalkService talkService;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
-    public TalkController(TalkService talkService, SimpMessagingTemplate simpMessagingTemplate) {
+    public TalkWebSocketController(TalkService talkService, SimpMessagingTemplate simpMessagingTemplate) {
         this.talkService = talkService;
         this.simpMessagingTemplate = simpMessagingTemplate;
     }

--- a/src/main/java/hatch/hatchserver2023/domain/talk/application/TalkService.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/application/TalkService.java
@@ -11,11 +11,16 @@ import org.springframework.stereotype.Service;
 public class TalkService {
     private final TalkRepository talkRepository;
 
-
     public TalkService(TalkRepository talkRepository) {
         this.talkRepository = talkRepository;
     }
 
+    /**
+     * 스테이지 라이브톡 전송 메세지 DB 저장 로직
+     * @param talkMessage : 저장할 메세지
+     * @param sender : 전송한 사용자
+     * @return
+     */
     public TalkMessage saveTalkMessage(TalkMessage talkMessage, User sender) {
         log.info("[SERVICE] saveTalkMessage");
         talkMessage.updateUser(sender);

--- a/src/main/java/hatch/hatchserver2023/domain/talk/application/TalkService.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/application/TalkService.java
@@ -32,7 +32,8 @@ public class TalkService {
     }
 
 
-    public Slice<TalkMessage> getTalkMessages(Pageable pageable) {
-        return talkRepository.findAll(pageable);
+    public Slice<TalkMessage> getTalkMessages(int page, int size) {
+        Pageable pageRequest = PageRequest.of(page, size, Sort.by("createdAt").descending()); //service 로?
+        return talkRepository.findAll(pageRequest);
     }
 }

--- a/src/main/java/hatch/hatchserver2023/domain/talk/application/TalkService.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/application/TalkService.java
@@ -4,7 +4,11 @@ import hatch.hatchserver2023.domain.talk.domain.TalkMessage;
 import hatch.hatchserver2023.domain.talk.repository.TalkRepository;
 import hatch.hatchserver2023.domain.user.domain.User;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
+
+//import java.awt.print.Pageable;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -25,5 +29,10 @@ public class TalkService {
         log.info("[SERVICE] saveTalkMessage");
         talkMessage.updateUser(sender);
         return talkRepository.save(talkMessage);
+    }
+
+
+    public Slice<TalkMessage> getTalkMessages(Pageable pageable) {
+        return talkRepository.findAll(pageable);
     }
 }

--- a/src/main/java/hatch/hatchserver2023/domain/talk/application/TalkService.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/application/TalkService.java
@@ -1,0 +1,24 @@
+package hatch.hatchserver2023.domain.talk.application;
+
+import hatch.hatchserver2023.domain.talk.domain.TalkMessage;
+import hatch.hatchserver2023.domain.talk.repository.TalkRepository;
+import hatch.hatchserver2023.domain.user.domain.User;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class TalkService {
+    private final TalkRepository talkRepository;
+
+
+    public TalkService(TalkRepository talkRepository) {
+        this.talkRepository = talkRepository;
+    }
+
+    public TalkMessage saveTalkMessage(TalkMessage talkMessage, User sender) {
+        log.info("[SERVICE] saveTalkMessage");
+        talkMessage.updateUser(sender);
+        return talkRepository.save(talkMessage);
+    }
+}

--- a/src/main/java/hatch/hatchserver2023/domain/talk/domain/TalkMessage.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/domain/TalkMessage.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter

--- a/src/main/java/hatch/hatchserver2023/domain/talk/domain/TalkMessage.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/domain/TalkMessage.java
@@ -1,0 +1,60 @@
+package hatch.hatchserver2023.domain.talk.domain;
+
+import hatch.hatchserver2023.domain.user.domain.User;
+import hatch.hatchserver2023.global.common.BaseTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Getter
+@Builder
+@Entity
+@Table(name = "talk_message")
+public class TalkMessage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @Column(nullable = false, unique = true)
+    private Long id;
+
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Type(type = "uuid-char")
+    @Column(nullable = false, length = 36, unique = true) // uuid 값이 36자의 문자열로 저장됨
+    private UUID uuid;
+
+    @Column(nullable = false, length = 200)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // uuid prepersist (auto generate) + BaseTimeEntity prePersist
+    @Override
+    public void prePersist() {
+        this.uuid = UUID.randomUUID(); //TODO : UUID2 전략 적용하기
+        super.prePersist(); //BaseTimeEntity
+    }
+
+    public TalkMessage(Long id, UUID uuid, String content, User user) {
+        this.id = id;
+        this.uuid = uuid;
+        this.content = content;
+        this.user = user;
+    }
+
+    public void updateUser(User user) {
+        this.user = user;
+    }
+
+    public TalkMessage() {
+
+    }
+}

--- a/src/main/java/hatch/hatchserver2023/domain/talk/dto/TalkRequestDto.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/dto/TalkRequestDto.java
@@ -5,26 +5,28 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
+import javax.validation.constraints.NotBlank;
+
 public class TalkRequestDto {
 
     @ToString
     @Getter
     @Builder
     public static class SendMessage{
+        @NotBlank
         private String content;
-//        private String tempSender; //TODO : 이건 필요없음. 인증은 토큰으로 할거니까
+
+        public TalkMessage toEntity() {
+            return TalkMessage.builder()
+                    .content(this.content)
+                    .build();
+        }
 
         public SendMessage() {
         }
 
         public SendMessage(String content) {
             this.content = content;
-        }
-
-        public TalkMessage toEntity() {
-            return TalkMessage.builder()
-                    .content(this.content)
-                    .build();
         }
     }
 }

--- a/src/main/java/hatch/hatchserver2023/domain/talk/dto/TalkRequestDto.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/dto/TalkRequestDto.java
@@ -1,0 +1,30 @@
+package hatch.hatchserver2023.domain.talk.dto;
+
+import hatch.hatchserver2023.domain.talk.domain.TalkMessage;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+public class TalkRequestDto {
+
+    @ToString
+    @Getter
+    @Builder
+    public static class SendMessage{
+        private String content;
+//        private String tempSender; //TODO : 이건 필요없음. 인증은 토큰으로 할거니까
+
+        public SendMessage() {
+        }
+
+        public SendMessage(String content) {
+            this.content = content;
+        }
+
+        public TalkMessage toEntity() {
+            return TalkMessage.builder()
+                    .content(this.content)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/hatch/hatchserver2023/domain/talk/dto/TalkResponseDto.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/dto/TalkResponseDto.java
@@ -1,10 +1,16 @@
 package hatch.hatchserver2023.domain.talk.dto;
 
-import hatch.hatchserver2023.domain.user.domain.User;
+import hatch.hatchserver2023.domain.talk.domain.TalkMessage;
 import hatch.hatchserver2023.domain.user.dto.UserResponseDto;
+import hatch.hatchserver2023.global.common.response.code.TalkStatusCode;
+import hatch.hatchserver2023.global.common.response.exception.TalkException;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 public class TalkResponseDto {
@@ -25,5 +31,47 @@ public class TalkResponseDto {
     public static class SendReaction{
         private String type;
         private String createdAt;
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    public static class GetMessagesContainer{
+        private Integer page;
+        private Integer size;
+        private List<BasicMessage> messages;
+
+        public static GetMessagesContainer toDto(Slice<TalkMessage> talkMessages) {
+            return GetMessagesContainer.builder()
+                    .page(talkMessages.getNumber())
+                    .size(talkMessages.getSize())
+                    .messages(BasicMessage.toDtos(talkMessages.getContent()))
+                    .build();
+        }
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    public static class BasicMessage{
+        private String content;
+        private String createdAt;
+        private UserResponseDto.SimpleUserProfile sender;
+
+        public static BasicMessage toDto(TalkMessage talkMessage) {
+            if(talkMessage.getCreatedTime() == null) {
+                throw new TalkException(TalkStatusCode.CREATED_TIME_NULL);
+            }
+
+            return BasicMessage.builder()
+                    .content(talkMessage.getContent())
+                    .createdAt(talkMessage.getCreatedTime().toString())
+                    .sender(UserResponseDto.SimpleUserProfile.toDto(talkMessage.getUser()))
+                    .build();
+        }
+
+        public static List<BasicMessage> toDtos(List<TalkMessage> messages) {
+            return messages.stream().map(BasicMessage::toDto).collect(Collectors.toList());
+        }
     }
 }

--- a/src/main/java/hatch/hatchserver2023/domain/talk/dto/TalkResponseDto.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/dto/TalkResponseDto.java
@@ -10,6 +10,7 @@ import lombok.ToString;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 
@@ -54,6 +55,7 @@ public class TalkResponseDto {
     @Getter
     @Builder
     public static class BasicMessage{
+        private UUID messageId;
         private String content;
         private String createdAt;
         private UserResponseDto.SimpleUserProfile sender;
@@ -64,6 +66,7 @@ public class TalkResponseDto {
             }
 
             return BasicMessage.builder()
+                    .messageId(talkMessage.getUuid())
                     .content(talkMessage.getContent())
                     .createdAt(talkMessage.getCreatedAt().toString())
                     .sender(UserResponseDto.SimpleUserProfile.toDto(talkMessage.getUser()))

--- a/src/main/java/hatch/hatchserver2023/domain/talk/dto/TalkResponseDto.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/dto/TalkResponseDto.java
@@ -1,0 +1,29 @@
+package hatch.hatchserver2023.domain.talk.dto;
+
+import hatch.hatchserver2023.domain.user.domain.User;
+import hatch.hatchserver2023.domain.user.dto.UserResponseDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+
+public class TalkResponseDto {
+
+    @ToString
+    @Getter
+    @Builder
+    public static class SendMessage{
+        private String type;
+        private String createdAt;
+        private String content;
+        private UserResponseDto.SimpleUserProfile sender;
+    }
+
+    @ToString
+    @Getter
+    @Builder
+    public static class SendReaction{
+        private String type;
+        private String createdAt;
+    }
+}

--- a/src/main/java/hatch/hatchserver2023/domain/talk/repository/TalkRepository.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/repository/TalkRepository.java
@@ -1,7 +1,12 @@
 package hatch.hatchserver2023.domain.talk.repository;
 
 import hatch.hatchserver2023.domain.talk.domain.TalkMessage;
+import org.springframework.data.domain.*;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+//import java.awt.print.Pageable;
 
 public interface TalkRepository extends JpaRepository<TalkMessage, Long> {
+    Page<TalkMessage> findAll(Pageable pageable);
 }

--- a/src/main/java/hatch/hatchserver2023/domain/talk/repository/TalkRepository.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/repository/TalkRepository.java
@@ -1,0 +1,7 @@
+package hatch.hatchserver2023.domain.talk.repository;
+
+import hatch.hatchserver2023.domain.talk.domain.TalkMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TalkRepository extends JpaRepository<TalkMessage, Long> {
+}

--- a/src/main/java/hatch/hatchserver2023/domain/user/api/AuthController.java
+++ b/src/main/java/hatch/hatchserver2023/domain/user/api/AuthController.java
@@ -36,14 +36,19 @@ public class AuthController {
         this.authService = authService;
     }
 
-
-    //TODO : 실행 못해봤음 - 프론트 연결하면서 해보기
+    /**
+     * 카카오 회원가입 & 로그인 한번에 진행되는 api
+     * @param type : "kakao" 고정값
+     * @param requestDto
+     * @param servletResponse
+     * @return
+     */
     @PostMapping("/login")
 //    @PreAuthorize("hasAnyRole('ROLE_ANONYMOUS')")
     public ResponseEntity<CommonResponse> kakaoSignUpAndLogin(@RequestParam @NotBlank String type,
                                                               @RequestBody @Valid UserRequestDto.KakaoLogin requestDto,
                                                               HttpServletResponse servletResponse) {
-        log.info("[API] POST auth/login");
+        log.info("[API] POST /auth/login");
 
         validLoginType(type);
 

--- a/src/main/java/hatch/hatchserver2023/domain/user/domain/User.java
+++ b/src/main/java/hatch/hatchserver2023/domain/user/domain/User.java
@@ -80,7 +80,7 @@ public class User extends BaseTimeEntity implements UserDetails {
     // uuid prepersist (auto generate) + BaseTimeEntity prePersist
     @Override
     public void prePersist() {
-        this.uuid = UUID.randomUUID();
+        this.uuid = UUID.randomUUID();  //TODO : UUID2 전략 적용하기
         super.prePersist(); //BaseTimeEntity
     }
 

--- a/src/main/java/hatch/hatchserver2023/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/hatch/hatchserver2023/domain/user/dto/UserResponseDto.java
@@ -26,4 +26,21 @@ public class UserResponseDto {
                     .build();
         }
     }
+
+    @ToString
+    @Getter
+    @Builder
+    public static class SimpleUserProfile {
+        private UUID userId;
+        private String nickname;
+        private String profileImg;
+
+        public static SimpleUserProfile toDto(User user) {
+            return SimpleUserProfile.builder()
+                    .userId(user.getUuid())
+                    .nickname(user.getNickname())
+                    .profileImg(user.getProfileImg())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/hatch/hatchserver2023/global/common/BaseTimeEntity.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/BaseTimeEntity.java
@@ -8,6 +8,7 @@ import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -33,4 +34,12 @@ public abstract class BaseTimeEntity {
         this.modifiedAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
     }
 
+
+    /**
+     * 테스트 시 필요한 메서드, 다른 기능에는 사용하지 말 것
+     * @param createdAt
+     */
+    public void updateForTestCode(ZonedDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/hatch/hatchserver2023/global/common/BaseTimeEntity.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/BaseTimeEntity.java
@@ -18,6 +18,7 @@ import java.time.ZonedDateTime;
 @EntityListeners(AuditingEntityListener.class) //Auditing 기능
 public abstract class BaseTimeEntity {
 
+    //TODO : NOT NULL 설정?
     private ZonedDateTime createdTime;
 
     private ZonedDateTime modifiedTime;

--- a/src/main/java/hatch/hatchserver2023/global/common/BaseTimeEntity.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/BaseTimeEntity.java
@@ -1,7 +1,6 @@
 package hatch.hatchserver2023.global.common;
 
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 

--- a/src/main/java/hatch/hatchserver2023/global/common/response/code/StatusCodeDoc.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/code/StatusCodeDoc.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum StatusCodeDoc {
     COMMON("COMMON", "공통", "/common", "공통 상태 코드", CommonCode.values()),
     USER("USER", "사용자", "/user", "사용자 상태 코드", UserStatusCode.values()),
+    TALK("TALK", "라이브톡", "/talk", "라이브톡 상태 코드", TalkStatusCode.values()),
     ;
 
     private final String initial;

--- a/src/main/java/hatch/hatchserver2023/global/common/response/code/TalkStatusCode.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/code/TalkStatusCode.java
@@ -1,0 +1,40 @@
+package hatch.hatchserver2023.global.common.response.code;
+
+import org.springframework.http.HttpStatus;
+
+public enum TalkStatusCode implements StatusCode {
+    // 2xx
+    GET_TALK_MESSAGES_SUCCESS(HttpStatus.OK, "2001", "라이브톡 메세지 목록 조회 성공"), //200
+
+    // 4xx
+
+    // 5xx
+    CREATED_TIME_NULL(HttpStatus.INTERNAL_SERVER_ERROR, "5001", "라이브톡 메세지의 생성 시각값이 존재하지 않음"), //500
+
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    TalkStatusCode(HttpStatus status, String code, String message){
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getCode() {
+        return StatusCodeDoc.TALK.getInitialWithConnector() + code;
+    }
+
+    @Override
+    public String getMessage() {
+        return StatusCodeDoc.TALK.getLabelWithBrackets() + message;
+    }
+}

--- a/src/main/java/hatch/hatchserver2023/global/common/response/code/UserStatusCode.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/code/UserStatusCode.java
@@ -17,7 +17,7 @@ public enum UserStatusCode implements StatusCode {
     UUID_IS_NULL(HttpStatus.UNAUTHORIZED, "4104", "UUID 값이 비었음"), //401
     COOKIE_LIST_IS_EMPTY(HttpStatus.UNAUTHORIZED, "4105", "쿠키 목록이 비었음"), //401
 
-    USER_PRE_FORBIDDEN(HttpStatus.FORBIDDEN, "4306", "사용자 권한 부족 (메서드 단위)"), //403
+    USER_PRE_FORBIDDEN(HttpStatus.FORBIDDEN, "4306", "사용자 권한 부족 (api 메서드 단위)"), //403
 //    NOT_FOUND(HttpStatus.NOT_FOUND, "404", "요청 리소스를 찾을 수 없음"), //404
 
 

--- a/src/main/java/hatch/hatchserver2023/global/common/response/exception/TalkException.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/exception/TalkException.java
@@ -1,0 +1,9 @@
+package hatch.hatchserver2023.global.common.response.exception;
+
+import hatch.hatchserver2023.global.common.response.code.StatusCode;
+
+public class TalkException extends DefaultException {
+    public TalkException(StatusCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/hatch/hatchserver2023/global/config/socket/JwtWebSocketInterceptor.java
+++ b/src/main/java/hatch/hatchserver2023/global/config/socket/JwtWebSocketInterceptor.java
@@ -1,0 +1,79 @@
+package hatch.hatchserver2023.global.config.socket;
+
+import hatch.hatchserver2023.domain.user.domain.User;
+import hatch.hatchserver2023.global.common.response.code.UserStatusCode;
+import hatch.hatchserver2023.global.common.response.exception.AuthException;
+import hatch.hatchserver2023.global.config.security.jwt.JwtProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 99) //인터셉터들 사이의 우선순위. jwt로직이 security설정보다 앞서야 함. 가장 높은 우선순위에 +99 하여 확실히 제일 높게 함
+// 소켓에서는 토큰 RTR 적용 일단 안함
+public class JwtWebSocketInterceptor implements ChannelInterceptor {
+    private final JwtProvider jwtProvider;
+
+    public JwtWebSocketInterceptor(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+
+
+    /**
+     * 메세지가 다른 사용자에게 발행되기 전에 실행되는 preSend 메서드. JWT 인증 로직
+     * @param message : 소켓 요청 내용 전체
+     * @param channel
+     * @return message
+     */
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        log.info("[INTERCEPTOR] WebSocketInterceptor preSend");
+        log.info("message : {}", message);
+//        log.info("native header : {}", headerAccessor.getHeader("nativeHeaders"));
+//        log.info("native header - Authorization : {}", headerAccessor.getFirstNativeHeader("Authorization"));
+
+        StompHeaderAccessor headerAccessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        //stomp 형식에서 요청 타입인 COMMAND 부분 값을 가져옴
+        StompCommand command = headerAccessor.getCommand();
+
+        //첫 연결 시, 메세지 발행 시에 로직 실행하도록 함 //TODO : 구독 시에는 어떻게 헤더 다는지 난 잘 모르겠음. 프론트와 논의
+        if(StompCommand.CONNECT == command || StompCommand.SEND == command) { //|| StompCommand.SUBSCRIBE == command // || StompCommand.MESSAGE == command
+            String token = headerAccessor.getFirstNativeHeader("Authorization");
+
+            //토큰 유효기간 확인 // TODO : 이거 예외 핸들러로 잡아주기!!!!!!! 예외응답!! -> 어떻게 하는 거지..? 공부하기
+            if(!jwtProvider.isTokenValid(token)){
+                throw new AuthException(UserStatusCode.TOKEN_CANNOT_RESOLVE);
+            }
+
+            // simpHeartbeat 내의 simpUser 라는 이름으로 인증정보(UsernamePasswordAuthenticationToken) 저장
+            // headerAccessor.setUser 로 Security 에 저장. WebSocketSecurityConfig 의 권한 검사, accessor.getsUser, SecurityHolder, @AuthenticationPrincipal 모두 사용가능
+            headerAccessor.setUser(jwtProvider.getAuthentication(token));
+
+            //확인 로그 찍기
+            Principal principal = headerAccessor.getUser();
+            log.info("[INTERCEPTOR] WebSocketInterceptor headerAccessor : getUser {}", principal);
+            if(principal instanceof UsernamePasswordAuthenticationToken) {
+                UsernamePasswordAuthenticationToken userToken = (UsernamePasswordAuthenticationToken) principal;
+                User user = (User) userToken.getPrincipal();
+                log.info("[INTERCEPTOR] WebSocketInterceptor headerAccessor : principal to User nickname {}", user.getNickname());
+            }
+        }
+
+        log.info("[INTERCEPTOR] END preSend");
+        return message;
+    }
+
+}

--- a/src/main/java/hatch/hatchserver2023/global/config/socket/JwtWebSocketInterceptor.java
+++ b/src/main/java/hatch/hatchserver2023/global/config/socket/JwtWebSocketInterceptor.java
@@ -49,6 +49,7 @@ public class JwtWebSocketInterceptor implements ChannelInterceptor {
         //stomp 형식에서 요청 타입인 COMMAND 부분 값을 가져옴
         StompCommand command = headerAccessor.getCommand();
 
+        //TODO : 만약 메세지 발행 시에는 토큰 확인 안하게 될 경우 이 부분 수정
         //첫 연결 시, 메세지 발행 시에 로직 실행하도록 함 //TODO : 구독 시에는 어떻게 헤더 다는지 난 잘 모르겠음. 프론트와 논의
         if(StompCommand.CONNECT == command || StompCommand.SEND == command) { //|| StompCommand.SUBSCRIBE == command // || StompCommand.MESSAGE == command
             String token = headerAccessor.getFirstNativeHeader(jwtProvider.ACCESS_TOKEN_NAME);

--- a/src/main/java/hatch/hatchserver2023/global/config/socket/JwtWebSocketInterceptor.java
+++ b/src/main/java/hatch/hatchserver2023/global/config/socket/JwtWebSocketInterceptor.java
@@ -55,6 +55,7 @@ public class JwtWebSocketInterceptor implements ChannelInterceptor {
 
             //토큰 유효기간 확인 // TODO : 이거 예외 핸들러로 잡아주기!!!!!!! 예외응답!! -> 어떻게 하는 거지..? 공부하기
             if(!jwtProvider.isTokenValid(token)){
+//                log.info("[INTERCEPTOR] WebSocketInterceptor : this token is invalid");
                 throw new AuthException(UserStatusCode.TOKEN_CANNOT_RESOLVE);
             }
 

--- a/src/main/java/hatch/hatchserver2023/global/config/socket/JwtWebSocketInterceptor.java
+++ b/src/main/java/hatch/hatchserver2023/global/config/socket/JwtWebSocketInterceptor.java
@@ -51,7 +51,7 @@ public class JwtWebSocketInterceptor implements ChannelInterceptor {
 
         //첫 연결 시, 메세지 발행 시에 로직 실행하도록 함 //TODO : 구독 시에는 어떻게 헤더 다는지 난 잘 모르겠음. 프론트와 논의
         if(StompCommand.CONNECT == command || StompCommand.SEND == command) { //|| StompCommand.SUBSCRIBE == command // || StompCommand.MESSAGE == command
-            String token = headerAccessor.getFirstNativeHeader("Authorization");
+            String token = headerAccessor.getFirstNativeHeader(jwtProvider.ACCESS_TOKEN_NAME);
 
             //토큰 유효기간 확인 // TODO : 이거 예외 핸들러로 잡아주기!!!!!!! 예외응답!! -> 어떻게 하는 거지..? 공부하기
             if(!jwtProvider.isTokenValid(token)){

--- a/src/main/java/hatch/hatchserver2023/global/config/socket/WebSocketConfig.java
+++ b/src/main/java/hatch/hatchserver2023/global/config/socket/WebSocketConfig.java
@@ -1,0 +1,38 @@
+package hatch.hatchserver2023.global.config.socket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+//@Order(Ordered.HIGHEST_PRECEDENCE + 99)
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final JwtWebSocketInterceptor jwtWebSocketInterceptor;
+
+    public WebSocketConfig(JwtWebSocketInterceptor jwtWebSocketInterceptor) {
+        this.jwtWebSocketInterceptor = jwtWebSocketInterceptor;
+    }
+
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-popo").setAllowedOriginPatterns("*"); //모든 곳으로부터의 요청 허용
+//        registry.addEndpoint("/ws-popo").withSockJS(); //socketJS 사용 허용
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic"); //구독, 전송
+        registry.setApplicationDestinationPrefixes("/app"); //발행
+    }
+
+    //(jwt 인증) interceptor 추가
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(jwtWebSocketInterceptor);
+    }
+}

--- a/src/main/java/hatch/hatchserver2023/global/config/socket/WebSocketSecurityConfig.java
+++ b/src/main/java/hatch/hatchserver2023/global/config/socket/WebSocketSecurityConfig.java
@@ -1,0 +1,26 @@
+package hatch.hatchserver2023.global.config.socket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.security.config.annotation.web.messaging.MessageSecurityMetadataSourceRegistry;
+import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
+
+//websocket 에서의 security 설정
+@Configuration
+public class WebSocketSecurityConfig extends AbstractSecurityWebSocketMessageBrokerConfigurer {
+    @Override
+    protected void configureInbound(MessageSecurityMetadataSourceRegistry messages) {
+        messages
+                .nullDestMatcher().permitAll() //destination 이 없는 CONNECT 등의 요청은 모두 허용
+                .simpTypeMatchers(SimpMessageType.CONNECT, SimpMessageType.HEARTBEAT, SimpMessageType.UNSUBSCRIBE, SimpMessageType.DISCONNECT).permitAll()
+                .simpDestMatchers("/app/**").authenticated() //발행 - 인증된 사용자만 허용
+                .simpSubscribeDestMatchers("/topic/**").authenticated() //구독 - 인증된 사용자만 허용
+                .anyMessage().denyAll() //그 외 모두 비허용
+                ;
+    }
+
+    @Override
+    protected boolean sameOriginDisabled() {
+        return true; //개발 중이므로 CSRF 비활성화
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   jpa:
     database: mysql
     hibernate:
-      ddl-auto: none #create, create-drop, none, update
+      ddl-auto: update #create, create-drop, none, update
       naming:
         physical-strategy: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy # set DB column name by snake case
     show-sql: true

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -456,6 +456,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_kakao_login"><strong>Kakao Login</strong></a></li>
 </ul>
 </li>
+<li><a href="#_talk_web_socket">Talk (Web Socket)</a>
+<ul class="sectlevel2">
+<li><a href="#_talk_message_send"><strong>Talk Message Send</strong></a></li>
+<li><a href="#_talk_reaction_send"><strong>Talk Reaction Send</strong></a></li>
+</ul>
+</li>
 <li><a href="#_status_code">Status Code</a>
 <ul class="sectlevel2">
 <li><a href="#_common">COMMON</a></li>
@@ -538,7 +544,7 @@ Expires: 0
 X-Frame-Options: DENY
 Content-Length: 159
 
-{"timeStamp":"2023/06/23 02:23:43","code":"COMMON-200","message":"[공통] 정상 처리","data":"Pocket Pose API Server : Health check ok. Server is running"}</code></pre>
+{"timeStamp":"2023/07/18 21:29:24","code":"COMMON-200","message":"[공통] 정상 처리","data":"Pocket Pose API Server : Health check ok. Server is running"}</code></pre>
 </div>
 </div>
 </div>
@@ -557,7 +563,7 @@ Content-Length: 159
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/auth/login?type=kakao HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 33
-X-CSRF-TOKEN: 98f62d95-4e21-4582-95cb-390c3c486c2d
+X-CSRF-TOKEN: d70b7da4-49ea-4ccd-b677-3ed340f2e6b3
 Host: localhost:8080
 
 {"kakaoAccessToken":"dummyToken"}</code></pre>
@@ -667,9 +673,145 @@ Expires: 0
 X-Frame-Options: DENY
 Content-Length: 228
 
-{"timeStamp":"2023/06/23 02:23:46","code":"USER-2000","message":"[사용자] 카카오 회원가입 및 로그인 성공","data":{"uuid":"6eaf514d-bb24-4ae2-a10a-6794d3675de0","nickname":"nicknameTest","email":"test@email.com"}}</code></pre>
+{"timeStamp":"2023/07/18 21:29:26","code":"USER-2000","message":"[사용자] 카카오 회원가입 및 로그인 성공","data":{"uuid":"2754e662-9bd0-451b-877e-0b355ed85039","nickname":"nicknameTest","email":"test@email.com"}}</code></pre>
 </div>
 </div>
+</div>
+<hr>
+</div>
+<h1 id="_talk_web_socket" class="sect0"><a class="link" href="#_talk_web_socket">Talk (Web Socket)</a></h1>
+<div class="sect2">
+<h3 id="_talk_message_send"><a class="link" href="#_talk_message_send"><strong>Talk Message Send</strong></a></h3>
+<div class="paragraph">
+<p>라이브톡 메세지 전송</p>
+</div>
+<div class="sect3">
+<h4 id="_requset_header"><a class="link" href="#_requset_header">Requset header</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필드명</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">타입</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필수여부</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">제약조건</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>x-access-token</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">JWT 형식</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_fields"><a class="link" href="#_request_fields">Request fields</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{"content":"안녕하세요~"}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필드명</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">타입</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필수여부</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">제약조건</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">공백 불가</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전송 메세지 내용</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_body"><a class="link" href="#_response_body">Response body</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필드명</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">타입</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필수여부</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>LocalDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">보낸 시각</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">메세지 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>type</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 타입(고정값 : message). 이 응답이 다른 사람의 메세지 전송을 전달하는 응답이라는 뜻</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>sender</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">보낸 사용자 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">보낸 사용자 고유값</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">보낸 사용자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>profileImg</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">보낸 사용자 프로필 사진</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_talk_reaction_send"><a class="link" href="#_talk_reaction_send"><strong>Talk Reaction Send</strong></a></h3>
+<div class="paragraph">
+<p>라이브톡 반응 전송</p>
 </div>
 <hr>
 </div>
@@ -770,7 +912,7 @@ Content-Length: 228
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>USER-4306</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">[사용자] 사용자 권한 부족 (메서드 단위)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[사용자] 사용자 권한 부족 (api 메서드 단위)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>USER-5001</code></p></td>
@@ -795,7 +937,7 @@ Content-Length: 228
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-06-20 20:44:08 +0900
+Last updated 2023-07-18 20:32:38 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -484,17 +484,22 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 </ul>
 </li>
+<li><a href="#_talk">Talk</a>
+<ul class="sectlevel2">
+<li><a href="#_get_talk_messages"><strong>Get Talk Messages</strong></a></li>
+</ul>
+</li>
 <li><a href="#_talk_web_socket">Talk (Web Socket)</a>
 <ul class="sectlevel2">
-<li><a href="#_talk_message_send"><strong>Talk Message Send</strong></a></li>
-<li><a href="#_talk_reaction_send"><strong>Talk Reaction Send</strong></a></li>
+<li><a href="#_send_talk_message"><strong>Send Talk Message</strong></a></li>
+<li><a href="#_send_talk_reaction"><strong>Send Talk Reaction</strong></a></li>
 </ul>
 </li>
 <li><a href="#_status_code">Status Code</a>
 <ul class="sectlevel2">
 <li><a href="#_common">COMMON</a></li>
 <li><a href="#_user_2">USER</a></li>
-<li><a href="#_talk">TALK</a></li>
+<li><a href="#_talk_2">TALK</a></li>
 <li><a href="#_video_2">VIDEO</a></li>
 <li><a href="#_s3">S3</a></li>
 </ul>
@@ -575,7 +580,7 @@ Expires: 0
 X-Frame-Options: DENY
 Content-Length: 159
 
-{"timeStamp":"2023/07/19 00:23:37","code":"COMMON-200","message":"[공통] 정상 처리","data":"Pocket Pose API Server : Health check ok. Server is running"}</code></pre>
+{"timeStamp":"2023/07/20 12:04:00","code":"COMMON-200","message":"[공통] 정상 처리","data":"Pocket Pose API Server : Health check ok. Server is running"}</code></pre>
 </div>
 </div>
 </div>
@@ -594,7 +599,7 @@ Content-Length: 159
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/auth/login?type=kakao HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 41
-X-CSRF-TOKEN: 6acf0c34-d11a-48ea-9df1-5939ca9c7425
+X-CSRF-TOKEN: ad2fa0dc-7cc6-42fa-85b6-27932b25ea0f
 Host: localhost:8080
 
 {
@@ -701,11 +706,11 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 282
 
 {
-  "timeStamp" : "2023/07/19 00:23:46",
+  "timeStamp" : "2023/07/20 12:04:14",
   "code" : "USER-2000",
   "message" : "[사용자] 카카오 회원가입 및 로그인 성공",
   "data" : {
-    "uuid" : "1027e531-e187-42c9-8f37-31ea1d0a5e26",
+    "uuid" : "99489413-e309-4cfe-bac4-69bc4f7080cb",
     "nickname" : "nicknameTest",
     "email" : "test@email.com"
   }
@@ -728,7 +733,7 @@ Content-Length: 282
 <h4 id="_영상_상세_조회_http_request"><a class="link" href="#_영상_상세_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/videos/468183ea-3e3a-451d-b281-fa85f4e3c886 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/videos/6b6d13f9-464f-47fe-bf36-75f7b900b0bf HTTP/1.1
 headerXAccessToken: headerXAccessToken
 headerXRefreshToken: headerXRefreshToken
 Host: localhost:8080</code></pre>
@@ -894,15 +899,15 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 676
 
 {
-  "timeStamp" : "2023/07/19 00:23:49",
+  "timeStamp" : "2023/07/20 12:04:20",
   "code" : "VIDEO-2003",
   "message" : "VIDEO-동영상 상세 정보 조회 성공",
   "data" : {
-    "uuid" : "468183ea-3e3a-451d-b281-fa85f4e3c886",
+    "uuid" : "6b6d13f9-464f-47fe-bf36-75f7b900b0bf",
     "title" : "타이틀",
     "tag" : "#해시 #태그",
     "user" : {
-      "uuid" : "9e4331cd-5449-444d-841d-ac869f153039",
+      "uuid" : "ed001fa8-a862-445a-8f67-1466376ef1b4",
       "nickname" : "닉네임",
       "email" : "이메일",
       "profileImg" : "프로필 이미지 s3 경로"
@@ -1070,16 +1075,16 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 1335
 
 {
-  "timeStamp" : "2023/07/19 00:23:49",
+  "timeStamp" : "2023/07/20 12:04:19",
   "code" : "VIDEO-2004",
   "message" : "VIDEO-동영상 목록 정보 조회 성공",
   "data" : {
     "videoList" : [ {
-      "uuid" : "4b912b40-1104-46c6-bd5b-beb8c97a28a7",
+      "uuid" : "e8d6d8fa-3ee5-4af5-89ba-673155f16623",
       "title" : "타이틀",
       "tag" : "#해시 #태그",
       "user" : {
-        "uuid" : "391d9260-aab1-464a-9ae3-532f1d6edd11",
+        "uuid" : "a6849d48-8a55-47e5-a7eb-0af9086eed4c",
         "nickname" : "닉네임",
         "email" : "이메일",
         "profileImg" : "프로필 이미지 s3 경로"
@@ -1092,11 +1097,11 @@ Content-Length: 1335
       "createdAt" : null,
       "liked" : false
     }, {
-      "uuid" : "698e3cdd-8f01-4e6f-b0d4-a67d32abe154",
+      "uuid" : "c95be04d-4d4f-4ca9-96d3-ad41ed9b7e15",
       "title" : "타이틀 1",
       "tag" : "#해시 #태그 #1",
       "user" : {
-        "uuid" : "391d9260-aab1-464a-9ae3-532f1d6edd11",
+        "uuid" : "a6849d48-8a55-47e5-a7eb-0af9086eed4c",
         "nickname" : "닉네임",
         "email" : "이메일",
         "profileImg" : "프로필 이미지 s3 경로"
@@ -1266,16 +1271,16 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 1335
 
 {
-  "timeStamp" : "2023/07/19 00:23:49",
+  "timeStamp" : "2023/07/20 12:04:19",
   "code" : "VIDEO-2004",
   "message" : "VIDEO-동영상 목록 정보 조회 성공",
   "data" : {
     "videoList" : [ {
-      "uuid" : "b3126786-fceb-42c5-a144-c81bb1064ab5",
+      "uuid" : "4289a773-9a2a-4323-8316-4a68fb7524d2",
       "title" : "타이틀",
       "tag" : "#해시 #태그",
       "user" : {
-        "uuid" : "dff56738-96b8-4e64-b4b1-16aea566839f",
+        "uuid" : "4b8d5b6a-b076-4637-8d3f-821a7762bd85",
         "nickname" : "닉네임",
         "email" : "이메일",
         "profileImg" : "프로필 이미지 s3 경로"
@@ -1288,11 +1293,11 @@ Content-Length: 1335
       "createdAt" : null,
       "liked" : false
     }, {
-      "uuid" : "6b887bad-edb7-458f-8afc-934af6f64ae9",
+      "uuid" : "6cd57f0e-9f53-4501-8c5a-aec732d2d342",
       "title" : "타이틀 1",
       "tag" : "#해시 #태그 #1",
       "user" : {
-        "uuid" : "dff56738-96b8-4e64-b4b1-16aea566839f",
+        "uuid" : "4b8d5b6a-b076-4637-8d3f-821a7762bd85",
         "nickname" : "닉네임",
         "email" : "이메일",
         "profileImg" : "프로필 이미지 s3 경로"
@@ -1318,7 +1323,7 @@ Content-Length: 1335
 <h4 id="_영상_삭제_http_request"><a class="link" href="#_영상_삭제_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/videos/d75c6776-0c3f-4d2d-93bd-528e812582ee?_csrf=1599b440-daea-406b-aa25-bcb974eca6fc HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/videos/ee6f0ba0-5e93-4cde-9b9e-26090a94d0e1?_csrf=b4307bf5-3f05-469e-9d1e-bbc419778b13 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1379,7 +1384,7 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 159
 
 {
-  "timeStamp" : "2023/07/19 00:23:49",
+  "timeStamp" : "2023/07/20 12:04:20",
   "code" : "VIDEO-2002",
   "message" : "VIDEO-동영상 삭제 성공",
   "data" : {
@@ -1414,7 +1419,7 @@ Content-Disposition: form-data; name=tag
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=_csrf
 
-22647617-ff44-4a1f-b17a-a40cbd5b35b7
+5969ee9b-826e-4805-a4cf-7cbe97098382
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=video; filename=video
 Content-Type: application/json
@@ -1510,11 +1515,11 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 193
 
 {
-  "timeStamp" : "2023/07/19 00:23:48",
+  "timeStamp" : "2023/07/20 12:04:18",
   "code" : "VIDEO-2001",
   "message" : "VIDEO-동영상 업로드 성공",
   "data" : {
-    "uuid" : "c2e5631f-eeb3-4146-93e4-db17308ed3a6"
+    "uuid" : "429d9930-4b97-44aa-925f-ac4eb05f4642"
   }
 }</code></pre>
 </div>
@@ -1563,7 +1568,7 @@ Content-Length: 193
 <h4 id="_댓글_등록_http_request"><a class="link" href="#_댓글_등록_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/comments/027862ab-3448-4ee3-ac1b-dd7e08f7088f?_csrf=a1e8c577-cf8d-4b1d-9e97-695138fb3f05 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/comments/9bf8edf4-7c1c-451c-9c0e-35c9d4d22aac?_csrf=8479373a-683b-44ed-b7c3-eeedb070a0fe HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 headerXAccessToken: headerXAccessToken
 headerXRefreshToken: headerXRefreshToken
@@ -1676,14 +1681,14 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 431
 
 {
-  "timeStamp" : "2023/07/19 00:23:41",
+  "timeStamp" : "2023/07/20 12:04:04",
   "code" : "VIDEO-2020",
   "message" : "VIDEO-댓글 등록 성공",
   "data" : {
-    "uuid" : "3c99ca14-296b-4483-bb38-cbfa922e3dde",
+    "uuid" : "be6c17ca-d57a-4a57-8cb0-3559fc99192f",
     "content" : "댓글을 작성했어요!",
     "user" : {
-      "uuid" : "fc3907f9-1099-4e5c-9ae2-626f77bd3477",
+      "uuid" : "631b6b56-71c5-41d8-aef5-e896eb858680",
       "nickname" : "닉네임",
       "email" : "이메일",
       "profileImg" : "프로필 이미지 s3 경로"
@@ -1700,7 +1705,7 @@ Content-Length: 431
 <h4 id="_댓글_삭제_http_request"><a class="link" href="#_댓글_삭제_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/comments/82a8faf8-6dea-4b50-8acf-d527b491703f?_csrf=9fb1d829-8af4-42e5-8b59-e04272947bdc HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/comments/1a4ef078-2cc7-4690-88aa-7d52675019cd?_csrf=ac29961c-a965-41d8-a066-2ffb5ae7732b HTTP/1.1
 headerXAccessToken: headerXAccessToken
 headerXRefreshToken: headerXRefreshToken
 Host: localhost:8080</code></pre>
@@ -1788,7 +1793,7 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 156
 
 {
-  "timeStamp" : "2023/07/19 00:23:40",
+  "timeStamp" : "2023/07/20 12:04:03",
   "code" : "VIDEO-2021",
   "message" : "VIDEO-댓글 삭제 성공",
   "data" : {
@@ -1805,7 +1810,7 @@ Content-Length: 156
 <h4 id="_동영상의_댓글_목록_조회_http_request"><a class="link" href="#_동영상의_댓글_목록_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/comments/fe35bb9d-63a0-4710-9013-5b84ba19fdee HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/comments/4cfae24b-204d-4ce8-bd2d-cf4ca6327250 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1902,25 +1907,25 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 872
 
 {
-  "timeStamp" : "2023/07/19 00:23:41",
+  "timeStamp" : "2023/07/20 12:04:04",
   "code" : "VIDEO-2022",
   "message" : "VIDEO-댓글 목록 조회 성공",
   "data" : {
     "commentList" : [ {
-      "uuid" : "83bc6927-8c02-457b-bbed-93b09bec63e7",
+      "uuid" : "f0d93d7d-a57a-4dc7-a257-6a02682abb6b",
       "content" : "댓글을 작성했어요!",
       "user" : {
-        "uuid" : "40db99b8-a056-4605-a2c3-6141339f16f5",
+        "uuid" : "c22231d3-7d3b-44d3-a0ac-5ada116c74b5",
         "nickname" : "닉네임",
         "email" : "이메일",
         "profileImg" : "프로필 이미지 s3 경로"
       },
       "createdAt" : null
     }, {
-      "uuid" : "1872b3ca-3e13-4618-9e0e-57fefe83778b",
+      "uuid" : "90b447c9-f5cf-4e90-8ea1-603447254176",
       "content" : "또 다른 댓글을 썼습니다",
       "user" : {
-        "uuid" : "40db99b8-a056-4605-a2c3-6141339f16f5",
+        "uuid" : "c22231d3-7d3b-44d3-a0ac-5ada116c74b5",
         "nickname" : "닉네임",
         "email" : "이메일",
         "profileImg" : "프로필 이미지 s3 경로"
@@ -1948,13 +1953,13 @@ Content-Length: 872
 <h4 id="_좋아요_등록_http_request"><a class="link" href="#_좋아요_등록_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/likes/bb1087aa-14c2-4006-a9cb-89ea42ccfb62 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/likes/383eaa25-ed36-4404-9f30-dbf6455f91ef HTTP/1.1
 headerXAccessToken: headerXAccessToken
 headerXRefreshToken: headerXRefreshToken
 Host: localhost:8080
 Content-Type: application/x-www-form-urlencoded
 
-_csrf=ec61b5dd-d9ca-4c39-98b2-7c0ee756c318</code></pre>
+_csrf=0d255dc3-d53f-41aa-b82e-7b22a6e04438</code></pre>
 </div>
 </div>
 </div>
@@ -2039,7 +2044,7 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 159
 
 {
-  "timeStamp" : "2023/07/19 00:23:44",
+  "timeStamp" : "2023/07/20 12:04:07",
   "code" : "VIDEO-2030",
   "message" : "VIDEO-좋아요 등록 성공",
   "data" : {
@@ -2056,7 +2061,7 @@ Content-Length: 159
 <h4 id="_좋아요_삭제_http_request"><a class="link" href="#_좋아요_삭제_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/likes/906cb90d-1a35-4eea-9786-7b36fe21e15e?_csrf=e1b904bc-9878-4651-94d7-330f1479e235 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/v1/likes/ecf0ed91-84cd-4837-9b9c-b9fa1304b411?_csrf=1e1a4489-8d2d-47c7-8c92-cc4894b04f26 HTTP/1.1
 headerXAccessToken: headerXAccessToken
 headerXRefreshToken: headerXRefreshToken
 Host: localhost:8080</code></pre>
@@ -2144,7 +2149,7 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 159
 
 {
-  "timeStamp" : "2023/07/19 00:23:44",
+  "timeStamp" : "2023/07/20 12:04:07",
   "code" : "VIDEO-2031",
   "message" : "VIDEO-좋아요 삭제 성공",
   "data" : {
@@ -2161,7 +2166,7 @@ Content-Length: 159
 <h4 id="_사용자_좋아요_영상_목록_조회_http_request"><a class="link" href="#_사용자_좋아요_영상_목록_조회_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/likes/67f4d696-45af-412b-833b-98cb40f1f7ff?page=0&amp;size=2 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/likes/462273d3-f3dc-40f3-9575-175928c53079?page=0&amp;size=2 HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2294,16 +2299,16 @@ Content-Type: application/json;charset=UTF-8
 Content-Length: 1342
 
 {
-  "timeStamp" : "2023/07/19 00:23:44",
+  "timeStamp" : "2023/07/20 12:04:07",
   "code" : "VIDEO-2032",
   "message" : "VIDEO-좋아요 누른 영상 목록 조회 성공",
   "data" : {
     "videoList" : [ {
-      "uuid" : "99820105-fc57-4e39-99ad-56a041c7b4e3",
+      "uuid" : "f24d2bc4-49dc-4137-83b0-0402398234b5",
       "title" : "타이틀",
       "tag" : "#해시 #태그",
       "user" : {
-        "uuid" : "67f4d696-45af-412b-833b-98cb40f1f7ff",
+        "uuid" : "462273d3-f3dc-40f3-9575-175928c53079",
         "nickname" : "닉네임",
         "email" : "이메일",
         "profileImg" : "프로필 이미지 s3 경로"
@@ -2316,11 +2321,11 @@ Content-Length: 1342
       "createdAt" : null,
       "liked" : false
     }, {
-      "uuid" : "3ac3b70f-e80e-4ddc-9f50-6e21297c28f0",
+      "uuid" : "91da983b-1748-4277-93ff-3de6ada7f685",
       "title" : "타이틀 1",
       "tag" : "#해시 #태그 #1",
       "user" : {
-        "uuid" : "67f4d696-45af-412b-833b-98cb40f1f7ff",
+        "uuid" : "462273d3-f3dc-40f3-9575-175928c53079",
         "nickname" : "닉네임",
         "email" : "이메일",
         "profileImg" : "프로필 이미지 s3 경로"
@@ -2343,9 +2348,161 @@ Content-Length: 1342
 </div>
 </div>
 </div>
+<h1 id="_talk" class="sect0"><a class="link" href="#_talk">Talk</a></h1>
+<div class="sect2">
+<h3 id="_get_talk_messages"><a class="link" href="#_get_talk_messages"><strong>Get Talk Messages</strong></a></h3>
+<div class="paragraph">
+<p>라이브톡 메세지 목록 조회(최신순) api</p>
+</div>
+<div class="sect3">
+<h4 id="_get_talk_messages_http_request"><a class="link" href="#_get_talk_messages_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/talks/messages?page=0&amp;size=3 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+X-CSRF-TOKEN: 4d7c475a-08b3-40b7-beaf-3f7824a14bfd
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_get_talk_messages_request_parameters"><a class="link" href="#_get_talk_messages_request_parameters">Request parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">파라미터</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필수여부</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 페이지 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회할 한 페이지 크기</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_get_talk_messages_response_fields-beneath-data"><a class="link" href="#_get_talk_messages_response_fields-beneath-data">Response fields-beneath-data</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필드명</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">타입</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">필수여부</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">설명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회된 페이지 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회된 한 페이지 크기</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>messages[].messageId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">메세지 식별자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>messages[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">메세지 전송 시각</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>messages[].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">메세지 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>messages[].sender.userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">메세지 전송자 식별자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>messages[].sender.nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">메세지 전송자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>messages[].sender.profileImg</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">메세지 전송자 프로필사진</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_get_talk_messages_http_response"><a class="link" href="#_get_talk_messages_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 932
+
+{
+  "timeStamp" : "2023/07/20 12:04:10",
+  "code" : "TALK-2001",
+  "message" : "[라이브톡] 라이브톡 메세지 목록 조회 성공",
+  "data" : {
+    "page" : 0,
+    "size" : 3,
+    "messages" : [ {
+      "messageId" : "3723eac0-6b8c-4d8b-8ae0-20ea02c6b333",
+      "content" : "1 메세지내용 test",
+      "createdAt" : "2023-07-20T12:04:10.777247500+09:00[Asia/Seoul]",
+      "sender" : {
+        "userId" : "71204da5-6377-4418-bdf2-54dcfb4f21e9",
+        "nickname" : "nicknameTest",
+        "profileImg" : "http://testurl"
+      }
+    }, {
+      "messageId" : "c78d4754-fc0a-43c1-b497-267f69ddbca2",
+      "content" : "2 메세지내용 test",
+      "createdAt" : "2023-07-20T12:04:10.777247500+09:00[Asia/Seoul]",
+      "sender" : {
+        "userId" : "71204da5-6377-4418-bdf2-54dcfb4f21e9",
+        "nickname" : "nicknameTest",
+        "profileImg" : "http://testurl"
+      }
+    } ]
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<hr>
+</div>
 <h1 id="_talk_web_socket" class="sect0"><a class="link" href="#_talk_web_socket">Talk (Web Socket)</a></h1>
 <div class="sect2">
-<h3 id="_talk_message_send"><a class="link" href="#_talk_message_send"><strong>Talk Message Send</strong></a></h3>
+<h3 id="_send_talk_message"><a class="link" href="#_send_talk_message"><strong>Send Talk Message</strong></a></h3>
 <div class="paragraph">
 <p>라이브톡 메세지 전송</p>
 </div>
@@ -2473,7 +2630,7 @@ Content-Length: 1342
 </div>
 </div>
 <div class="sect2">
-<h3 id="_talk_reaction_send"><a class="link" href="#_talk_reaction_send"><strong>Talk Reaction Send</strong></a></h3>
+<h3 id="_send_talk_reaction"><a class="link" href="#_send_talk_reaction"><strong>Send Talk Reaction</strong></a></h3>
 <div class="paragraph">
 <p>라이브톡 반응 전송</p>
 </div>
@@ -2663,7 +2820,7 @@ Content-Length: 1342
 </table>
 </div>
 <div class="sect2">
-<h3 id="_talk"><a class="link" href="#_talk">TALK</a></h3>
+<h3 id="_talk_2"><a class="link" href="#_talk_2">TALK</a></h3>
 <div class="paragraph">
 <p>라이브톡 상태 코드</p>
 </div>
@@ -2826,7 +2983,7 @@ Content-Length: 1342
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-07-19 00:04:51 +0900
+Last updated 2023-07-20 12:02:43 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/static/docs/code.html
+++ b/src/main/resources/static/docs/code.html
@@ -550,7 +550,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>USER-4306</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">[사용자] 사용자 권한 부족 (메서드 단위)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[사용자] 사용자 권한 부족 (api 메서드 단위)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>USER-5001</code></p></td>

--- a/src/test/java/hatch/hatchserver2023/domain/talk/api/TalkControllerTest.java
+++ b/src/test/java/hatch/hatchserver2023/domain/talk/api/TalkControllerTest.java
@@ -1,0 +1,181 @@
+package hatch.hatchserver2023.domain.talk.api;
+
+import hatch.hatchserver2023.domain.talk.application.TalkService;
+import hatch.hatchserver2023.domain.talk.domain.TalkMessage;
+import hatch.hatchserver2023.domain.user.domain.User;
+import hatch.hatchserver2023.global.common.response.code.StatusCode;
+import hatch.hatchserver2023.global.common.response.code.TalkStatusCode;
+import hatch.hatchserver2023.global.common.response.code.UserStatusCode;
+import hatch.hatchserver2023.global.config.restdocs.RestDocsConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.*;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@Slf4j
+@WebMvcTest(controllers = {TalkController.class})
+@MockBean(JpaMetamodelMappingContext.class)
+@Import(RestDocsConfig.class)
+@ExtendWith(RestDocumentationExtension.class)
+@AutoConfigureRestDocs
+class TalkControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    RestDocumentationResultHandler docs;
+
+    @MockBean
+    private TalkService talkService;
+
+    private UUID uuid;
+    private String nickname;
+    private String profileImg;
+
+    @BeforeEach
+    void setUp(final WebApplicationContext context,
+               final RestDocumentationContextProvider provider) {
+        log.info("set up");
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(MockMvcRestDocumentation.documentationConfiguration(provider))  // rest docs 설정 주입
+                .alwaysDo(MockMvcResultHandlers.print()) // andDo(print()) 코드 포함
+                .alwaysDo(docs) // pretty 패턴과 문서 디렉토리 명 정해준것 적용
+                .addFilters(new CharacterEncodingFilter("UTF-8", true)) // 한글 깨짐 방지
+                .build();
+
+        log.info("set up");
+        uuid = UUID.randomUUID();
+        nickname = "nicknameTest";
+        profileImg = "http://testurl";
+    }
+
+
+    @Test
+    void getTalkMessages() throws Exception {
+        //given
+        int page = 0;
+        int size = 3;
+        ZonedDateTime now = ZonedDateTime.now();
+
+        User sender = User.builder()
+                .uuid(uuid)
+                .profileImg(profileImg)
+                .nickname(nickname)
+                .build();
+        TalkMessage talkMessage1 = TalkMessage.builder()
+                .uuid(UUID.randomUUID())
+//                .id(0L)
+                .content("1 메세지내용 test")
+                .user(sender)
+                .build();
+        TalkMessage talkMessage2 = TalkMessage.builder()
+                .uuid(UUID.randomUUID())
+//                .id(0L)
+                .content("2 메세지내용 test")
+                .user(sender)
+                .build();
+        talkMessage1.updateForTestCode(now);
+        talkMessage2.updateForTestCode(now);
+
+        List<TalkMessage> talkMessageList = List.of(talkMessage1, talkMessage2);
+        Pageable pageable = PageRequest.of(page, size);
+
+        Slice<TalkMessage> talkMessages = new SliceImpl<TalkMessage>(talkMessageList, pageable, false);
+
+
+        //when
+        when(talkService.getTalkMessages(page,size)).thenReturn(talkMessages);
+
+        //then
+        MockHttpServletRequestBuilder requestGet = get("/api/v1/talks/messages")
+                .param("page", String.valueOf(page))
+                .param("size", String.valueOf(size))
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf().asHeader()); // csrf가 request parameter 로 들어갈 경우 문서화 필수 오류 해결
+
+        ResultActions resultActions = mockMvc.perform(requestGet);
+
+        StatusCode code = TalkStatusCode.GET_TALK_MESSAGES_SUCCESS;
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(code.getCode()))
+                .andExpect(jsonPath("$.message").value(code.getMessage()))
+                .andExpect(jsonPath("$.data.page").value(page)) //.toString()
+                .andExpect(jsonPath("$.data.size").value(size))
+                .andExpect(jsonPath("$.data.messages[0].messageId").value(talkMessage1.getUuid().toString()))
+                .andExpect(jsonPath("$.data.messages[0].content").value(talkMessage1.getContent()))
+                .andExpect(jsonPath("$.data.messages[0].sender.userId").value(sender.getUuid().toString()))
+                .andExpect(jsonPath("$.data.messages[0].sender.nickname").value(sender.getNickname()))
+                .andExpect(jsonPath("$.data.messages[0].sender.profileImg").value(sender.getProfileImg()))
+                .andExpect(jsonPath("$.data.messages[1].messageId").value(talkMessage2.getUuid().toString()))
+                .andExpect(jsonPath("$.data.messages[1].content").value(talkMessage2.getContent()))
+                .andExpect(jsonPath("$.data.messages[1].sender.userId").value(sender.getUuid().toString()))
+                .andExpect(jsonPath("$.data.messages[1].sender.nickname").value(sender.getNickname()))
+                .andExpect(jsonPath("$.data.messages[1].sender.profileImg").value(sender.getProfileImg()))
+        ;
+
+
+        resultActions
+                .andDo(
+                        docs.document(
+                                requestParameters(
+                                        parameterWithName("page").description("조회할 페이지 번호"),
+                                        parameterWithName("size").description("조회할 한 페이지 크기")
+                                ),
+                                responseFields(
+                                        beneathPath("data"),
+                                        fieldWithPath("page").type("Integer").description("조회된 페이지 번호"),
+                                        fieldWithPath("size").type("Integer").description("조회된 한 페이지 크기"),
+                                        fieldWithPath("messages[].messageId").type("UUID").description("메세지 식별자"),
+                                        fieldWithPath("messages[].createdAt").type("LocalDateTime").description("메세지 전송 시각"),
+                                        fieldWithPath("messages[].content").type(JsonFieldType.STRING).description("메세지 내용"),
+                                        fieldWithPath("messages[].sender.userId").type("UUID").description("메세지 전송자 식별자"),
+                                        fieldWithPath("messages[].sender.nickname").type(JsonFieldType.STRING).description("메세지 전송자 닉네임"),
+                                        fieldWithPath("messages[].sender.profileImg").type(JsonFieldType.STRING).description("메세지 전송자 프로필사진")
+                                )
+                        )
+                )
+        ;
+    }
+}

--- a/src/test/java/hatch/hatchserver2023/global/common/response/code/docs/StatusCodeController.java
+++ b/src/test/java/hatch/hatchserver2023/global/common/response/code/docs/StatusCodeController.java
@@ -2,6 +2,7 @@ package hatch.hatchserver2023.global.common.response.code.docs;
 
 import hatch.hatchserver2023.global.common.response.code.CommonCode;
 import hatch.hatchserver2023.global.common.response.code.StatusCode;
+import hatch.hatchserver2023.global.common.response.code.TalkStatusCode;
 import hatch.hatchserver2023.global.common.response.code.UserStatusCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,11 @@ public class StatusCodeController {
     @GetMapping("/user")
     public ResponseEntity<StatusCodeView> getUserStatusCodes() {
         return getResponse(UserStatusCode.values());
+    }
+
+    @GetMapping("/talk")
+    public ResponseEntity<StatusCodeView> getTalkStatusCodes() {
+        return getResponse(TalkStatusCode.values());
     }
 
     private ResponseEntity<StatusCodeView> getResponse(StatusCode[] statusCodes) {


### PR DESCRIPTION
🏷️ Jira issue : HH-195~199

― PR 유형 ―
- 기능 추가
- 빌드 관련 코드 업데이트(명세)


<br>

## 📑 작업 내용 
- 웹소켓 통신 세팅
- 라이브톡 메세지, 반응 전송 웹소켓 기능 개발
- 라이브톡 메세지 목록 조회 api 개발
- 문서화 중 웹소켓 기능은 테스트코드 작성 및 자동 문서화 불가능해서 직접 adoc 파일 작성했음
- 웹소켓 테스트 툴 소개글 작성 #30 


<br>

## 📌 주요 집중 포인트
- TalkWebSocketController : 웹소켓의 메세지 전송 요청들이 맵핑되는 컨트롤러
- src.docs.asciidocs.talk-socket 패키지 : 직접 작성한 adoc 문서들 (talk도메인에 해당하는 소켓통신 기능)


<br>

## 🔥 어려웠던 부분 & 트러블 슈팅
소켓통신으로 만든 컨트롤러 메서드들 테스트코드 작성법 결국 못찾았네요..
rest docs 는 rest api 를 위한 툴이라 웹소켓 기능 명세는 지원하지 않는 것 같기도 합니다.
단위테스트는 안되더라도 통합테스트 코드는 언젠간 성공해보고싶은 맘..

<br>

## 🐣 앞으로 할 일
- 웹소켓 테스트 툴 소개 -> 완료! #30 
- redis 적용 & 스테이지 개발


<br>

### 📎기타 사항
지금은 메세지 전송 시마다 토큰을 확인하도록 만들었는데, 
꼭 그렇게 안하는 경우도 많은 것 같아서
프론트에서 어렵다 하거나 불필요하다고 판단되면 소켓통신 중에는 토큰 인증 안하게 수정될 가능성도 염두에 두고 있슴다

커밋 더 작게 했어야 했는데 반성하고 있습니다..