### PR TITLE
[배포&리뷰] [transaction] stage관련 service, talk, chat, authService 에 RDB 트랜잭션 설정

### DIFF
--- a/src/main/java/hatch/hatchserver2023/domain/like/LikeCacheUtil.java
+++ b/src/main/java/hatch/hatchserver2023/domain/like/LikeCacheUtil.java
@@ -31,14 +31,12 @@ public class LikeCacheUtil {
 
     private final RedisDao redisDao;
     private final VideoCacheUtil videoCacheUtil;
-    private final VideoRepository videoRepository;
     private final LikeRepository likeRepository;
     private final UserRepository userRepository;
 
-    public LikeCacheUtil(RedisDao redisDao, VideoCacheUtil videoCacheUtil, VideoRepository videoRepository, LikeRepository likeRepository, UserRepository userRepository) {
+    public LikeCacheUtil(RedisDao redisDao, VideoCacheUtil videoCacheUtil, LikeRepository likeRepository, UserRepository userRepository) {
         this.redisDao = redisDao;
         this.videoCacheUtil = videoCacheUtil;
-        this.videoRepository = videoRepository;
         this.likeRepository = likeRepository;
         this.userRepository = userRepository;
     }
@@ -172,6 +170,8 @@ public class LikeCacheUtil {
      * @param deleteLikes
      */
     private void makeLikes(String key, Video video, List<Like> addLikes, List<Like> deleteLikes) {
+        // TODO : UserRepository 의존성 없애려면 redisDao.getHashKeys()랑 getUser()를 UserService에서 처리하고 그 결과를 List<User>로 받아와서 반복문 돌면 됨
+
         Set<String> userIds = redisDao.getHashKeys(key);
         for(String userId : userIds) {
             log.info("[SCHEDULED] hashKey userId : {}", userId);

--- a/src/main/java/hatch/hatchserver2023/domain/like/application/LikeService.java
+++ b/src/main/java/hatch/hatchserver2023/domain/like/application/LikeService.java
@@ -89,6 +89,7 @@ public class LikeService {
      */
     public Slice<VideoModel.VideoInfo> getLikedVideoList(UUID userId, User loginUser, Pageable pageable){
 
+        //TODO : repository 의존성 제거
         User user = userRepository.findByUuid(userId)
                 .orElseThrow(() -> new AuthException(UserStatusCode.UUID_NOT_FOUND));
 

--- a/src/main/java/hatch/hatchserver2023/domain/stage/api/MusicController.java
+++ b/src/main/java/hatch/hatchserver2023/domain/stage/api/MusicController.java
@@ -10,12 +10,14 @@ import hatch.hatchserver2023.global.common.response.exception.DefaultException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
 
 @Slf4j
+@Transactional(readOnly = true) // service는 아니지만 music은 로직이 단순해 예외적으로 service 없이 controller에서 로직을 처리하므로 트랜잭션 적용
 @RestController
 @RequestMapping("api/v1/musics")
 @RequiredArgsConstructor
@@ -31,6 +33,7 @@ public class MusicController {
      *  @input title, singer, length, answer, concept, music_url
       * @return success
      */
+    @Transactional
     @PostMapping("/save")
     public ResponseEntity<Object> saveMusic(@RequestBody MusicRequestDto request) {
 
@@ -54,6 +57,7 @@ public class MusicController {
     }
 
     //삭제
+    @Transactional
     @DeleteMapping("/delete/{title}")
     public ResponseEntity<CommonResponse> deleteMusic(@PathVariable String title) {
         Music music = musicRepository.findByTitle(title);

--- a/src/main/java/hatch/hatchserver2023/domain/stage/application/AIService.java
+++ b/src/main/java/hatch/hatchserver2023/domain/stage/application/AIService.java
@@ -9,11 +9,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.List;
 
 @Slf4j
+@Transactional(readOnly = true)
 @Service
 public class AIService {
     // 환경변수 주입

--- a/src/main/java/hatch/hatchserver2023/domain/stage/application/StageService.java
+++ b/src/main/java/hatch/hatchserver2023/domain/stage/application/StageService.java
@@ -9,6 +9,7 @@ import hatch.hatchserver2023.global.common.response.exception.StageException;
 import hatch.hatchserver2023.global.config.redis.RedisDao;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
+//@Transactional(readOnly = true) // repository가 쓰이는 곳에 없음. 다 redis 임
 @Service
 public class StageService {
 

--- a/src/main/java/hatch/hatchserver2023/domain/stage/application/StageSocketService.java
+++ b/src/main/java/hatch/hatchserver2023/domain/stage/application/StageSocketService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import java.util.Arrays;
 
 @Slf4j
+//@Transactional(readOnly = true) // repository가 쓰이는 곳에 없음. 다 redis 임
 @Service
 public class StageSocketService {
     private final StageDataUtil stageDataUtil;

--- a/src/main/java/hatch/hatchserver2023/domain/talk/application/TalkService.java
+++ b/src/main/java/hatch/hatchserver2023/domain/talk/application/TalkService.java
@@ -6,11 +6,13 @@ import hatch.hatchserver2023.domain.user.domain.User;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 //import java.awt.print.Pageable;
 import java.util.List;
 
 @Slf4j
+@Transactional(readOnly = true)
 @Service
 public class TalkService {
     private final TalkRepository talkRepository;
@@ -25,6 +27,7 @@ public class TalkService {
      * @param sender : 전송한 사용자
      * @return
      */
+    @Transactional
     public TalkMessage saveTalkMessage(TalkMessage talkMessage, User sender) {
         log.info("[SERVICE] saveTalkMessage");
         talkMessage.updateUser(sender);

--- a/src/main/java/hatch/hatchserver2023/domain/user/application/AuthService.java
+++ b/src/main/java/hatch/hatchserver2023/domain/user/application/AuthService.java
@@ -6,6 +6,7 @@ import hatch.hatchserver2023.domain.user.repository.UserRepository;
 import hatch.hatchserver2023.global.config.security.jwt.JwtProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
@@ -15,7 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
-//@RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class AuthService {
 
@@ -27,6 +28,7 @@ public class AuthService {
         this.jwtProvider = jwtProvider;
     }
 
+    @Transactional //signUp 을 여기서 사용함 - 나중에 로직 개선하기
     public User signUpAndLogin(@Valid KakaoDto.GetUserInfo userInfo, HttpServletResponse servletResponse) {
         log.info("[SERVICE] signUpAndLogin");
         Optional<User> userOp = userRepository.findByKakaoAccountNumber(userInfo.getKakaoAccountNumber());

--- a/src/main/java/hatch/hatchserver2023/domain/video/api/VideoController.java
+++ b/src/main/java/hatch/hatchserver2023/domain/video/api/VideoController.java
@@ -1,6 +1,5 @@
 package hatch.hatchserver2023.domain.video.api;
 
-import hatch.hatchserver2023.domain.like.LikeCacheUtil;
 import hatch.hatchserver2023.domain.user.domain.User;
 import hatch.hatchserver2023.domain.video.VideoCacheUtil;
 import hatch.hatchserver2023.domain.video.application.HashtagService;

--- a/src/main/java/hatch/hatchserver2023/global/common/response/code/StageStatusCode.java
+++ b/src/main/java/hatch/hatchserver2023/global/common/response/code/StageStatusCode.java
@@ -18,7 +18,7 @@ public enum StageStatusCode implements StatusCode {
     STAGE_STATUS_NOT_CATCH(HttpStatus.INTERNAL_SERVER_ERROR, "5003", "스테이지 상태가 캐치가 아님"), //500
     STAGE_STATUS_NOT_PLAY(HttpStatus.INTERNAL_SERVER_ERROR, "5004", "스테이지 상태가 플레이가 아님"), //500
 //    STAGE_PLAYER_NUM_OUT_OF_BOUNDS(HttpStatus.INTERNAL_SERVER_ERROR, "5005", "스테이지 플레이어 번호가 유효 범위를 벗어남"), //500
-    FAIL_SAVE_MVP_USER_INFO_JSON(HttpStatus.INTERNAL_SERVER_ERROR, "5006", "스테이지 플레이어 사용자 정보 json 변환 저장 실패"), //500
+    FAIL_CONVERT_REDIS_SKELETON_DATA_TO_ARRAY(HttpStatus.INTERNAL_SERVER_ERROR, "5006", "스테이지 플레이어 스켈레톤 정보 배열로 변환 실패"), //500
     FAIL_GET_MVP_USER_INFO_FROM_REDIS_JSON(HttpStatus.INTERNAL_SERVER_ERROR, "5007", "스테이지 mvp 사용자 정보 json 맵핑 실패"), //500
     STAGE_STATUS_NOT_MVP(HttpStatus.INTERNAL_SERVER_ERROR, "5008", "스테이지 상태가 캐치가 아님"), //500
     NOT_ENTERED_USER(HttpStatus.INTERNAL_SERVER_ERROR, "5009", "스테이지에 입장했던 사용자가 아니기에 퇴장할 수 없음"), //500


### PR DESCRIPTION
🏷️ Jira issue : -

― PR 유형 ―
- 기존 기능 수정
- 코드 리팩토링 또는 정리


<br>

## 📑 작업 내용 
- 제가 구현 담당이었던 부분 위주로 \@Transactional 을 사용해서 트랜잭션 설정을 했습니다.
적용한 service파일은 다음과 같고, 이 service파일에서 사용중인 repository들을 검토했습니다.
  - AuthService
  - TalkService
  - ChatService
  - Stage관련
    - AIService
    - StageService (검토했으나 repository 사용하지 않아 트랜잭션 사용은 x)
    - StageSocketService (검토했으나 repository 사용하지 않아 트랜잭션 사용은 x)
    - StageRoutineService
    - MusicController (music 은 controller에서 비즈니스 로직을 처리하므로)


<br>

## 📌 주요 집중 포인트
- 제가 선언적 트랜잭션 적용한 규칙은 다음과 같습니다.
  - service 를 트랜잭션의 시작과 종료 지점으로 설정.
  -> service 클래스단에 읽기 작업만 허용하는 \@Transactional(readOnly=true) 붙임
       생성/수정/삭제 작업을 하는 메서드에 쓰기 작업을 허용하기 위해 \@Transactional 붙임
  - repository 를 사용하여 DB에 접근하는 메서드 중 예외를 발생시키는 곳이 존재하는 메서드는 해당 예외 발생 시 DB 롤백이 필요한지 검토하고, 필요하다고 판단되면 해당 예외 발생 시 롤백하도록 설정함
  - 내부 호출 검토 : 트랜잭션이 중요한 메서드 중 같은 클래스 내부에서 호출되는 메서드가 있는지 검토함
  - repository 가 service 클래스 외 다른 곳에서 호출되고 있는 곳이 있는지 검토함 (트랜잭션 관리 범위 밖이므로 사용되지 않도록 하기)
  - 테스트 코드의 클래스단에 \@Transactional 을 붙여서 테스트 중 발생하는 DB변경을 롤백
  (이건 저희가 현재 controller 단위 테스트 코드만 작성하고 있어서 DB접근하는 부분이 없어 결과적으로는 적용하지 않았습니다)


<br>

## 🔥 어려웠던 부분 & 트러블 슈팅
짤 때 제대로 짜는 게 제일 쉽네요.. 내가 짠 코드도 쉽게 읽히지 않는 매직


<br>

## 🐣 앞으로 할 일
redis 트랜잭션, 동시성 관리
푸시알림
채팅 최근메세지 정보 redis
중간 유사도


<br>

### 📎기타 사항
중간 유사도 veryvery 걱정쓰