### PR TITLE
[feat] 댓글 작성에 푸시알림 추가

### DIFF
--- a/src/docs/asciidoc/Comment-API.adoc
+++ b/src/docs/asciidoc/Comment-API.adoc
@@ -2,7 +2,7 @@
 
 
 
-- link:comment/page/post-add-comment.html[댓글 추가, window=_blank]
+- link:comment/page/post-add-comment.html[ (UPDATE) 댓글 추가, window=_blank]
 
 
 - link:comment/page/delete-comment.html[댓글 삭제, window=_blank]

--- a/src/docs/asciidoc/User-API.adoc
+++ b/src/docs/asciidoc/User-API.adoc
@@ -14,7 +14,7 @@
 
 - link:user/page/update-profile.html[ 프로필 수정,window=_blank]
 
-- link:user/page/search-user.html[ (UPDATE) 계정 검색,window=_blank]
+- link:user/page/search-user.html[ 계정 검색,window=_blank]
 
 
 

--- a/src/docs/asciidoc/comment/page/post-add-comment.adoc
+++ b/src/docs/asciidoc/comment/page/post-add-comment.adoc
@@ -1,3 +1,36 @@
 == 댓글 등록
 
+NOTE: 가장 아래에 댓글 작성 푸시알림 관련 명세가 있습니다.
+
 operation::post-add-comment[snippets='http-request,request-headers,request-body,response-fields-beneath-data,http-response']
+
+=== Push Notification fields
+
+푸시알림 시 전달되는 데이터 정보
+
+NOTE: 김수빈 사용자가 "안녕하세요~" 라는 댓글을 작성하면, +
+title은 "안녕하세요~", content는 "김수빈님이 댓글을 남겼습니다." 라고 푸시알림이 오게됩니다.
+
+|===
+|전달방식|필드명|타입|필수여부|설명
+|title
+|`+-+`
+|`+String+`
+|true
+|작성한 댓글 내용
+|content
+|`+-+`
+|`+String+`
+|true
+|댓글 작성자의 닉네임 + "님이 댓글을 남겼습니다."
+|data
+|`+type+`
+|`+String+`
+|true
+|알림 유형. 고정값(ADD_COMMENT)
+|data
+|`+commentId+`
+|`+UUID+`
+|true
+|생성된 댓글의 UUID
+|===

--- a/src/main/java/hatch/hatchserver2023/domain/comment/application/CommentFcmUtil.java
+++ b/src/main/java/hatch/hatchserver2023/domain/comment/application/CommentFcmUtil.java
@@ -1,0 +1,66 @@
+package hatch.hatchserver2023.domain.comment.application;
+
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import hatch.hatchserver2023.domain.comment.domain.Comment;
+import hatch.hatchserver2023.domain.user.domain.User;
+import hatch.hatchserver2023.global.common.response.code.UserStatusCode;
+import hatch.hatchserver2023.global.common.response.exception.AuthException;
+import hatch.hatchserver2023.global.config.firebase.FcmNotificationUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class CommentFcmUtil {
+
+    private static final String KEY_ADD_COMMENT_ID = "commentId";
+
+    private final FcmNotificationUtil fcmNotificationUtil;
+
+    public CommentFcmUtil(FcmNotificationUtil fcmNotificationUtil) {
+        this.fcmNotificationUtil = fcmNotificationUtil;
+    }
+
+    //푸시 알림 로직
+    public void sendAddCommentNotification(User receiver, Comment comment){
+        log.info("[FCM] sendAddCommentNotification");
+
+        // FCM 토큰이 존재하는 사용자인지 확인
+        try {
+            fcmNotificationUtil.checkFcmTokenExist(receiver);
+        } catch (AuthException e) {
+            if(e.getCode() == UserStatusCode.FCM_NOTIFICATION_TOKEN_NOT_FOUND){
+                log.info("이 사용자의 FCM 토큰이 존재하지 않아 알림을 전송할 수 없음");
+                return; // 알림 전송하지 않고 종료
+            }
+        }
+
+        // FCM 토큰 가져와서 알림 요청 내용(Message) 생성
+        String token = fcmNotificationUtil.getFcmToken(receiver);
+        Message message = createMessage(token, comment);
+
+        // 알림 전송 요청
+        fcmNotificationUtil.send(message);
+    }
+
+
+    //알림 요청 내용(Message)를 생성
+    private Message createMessage(String token, Comment comment){
+        //푸시알림 객체 생성
+        Notification notification = Notification.builder()
+                .setTitle(comment.getContent())  //푸시알림의 제목
+                .setBody(comment.getUser().getNickname()+"님이 댓글을 남겼습니다.")  //푸시알림의 내용
+                .build();
+
+        //요청 내용 생성 : 알림 받을 사용자의 토큰, 푸시알림 객체, 푸시알림에 보여질 내용 외에 전달해야하는 데이터들을 key-value 형태로 담아 생성
+        return Message.builder()
+                .setToken(token)
+                .setNotification(notification)
+                .putData(FcmNotificationUtil.DATA_KEY_TYPE, FcmNotificationUtil.TYPE_ADD_COMMENT)   //푸시 알림의 type
+                .putData(KEY_ADD_COMMENT_ID, String.valueOf(comment.getUuid())) //푸시알림 시 전달해야하는 데이터
+                .build();
+    }
+}

--- a/src/main/java/hatch/hatchserver2023/domain/comment/application/CommentService.java
+++ b/src/main/java/hatch/hatchserver2023/domain/comment/application/CommentService.java
@@ -21,10 +21,12 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final VideoCacheUtil videoCacheUtil;
+    private final CommentFcmUtil commentFcmUtil;
 
-    public CommentService(CommentRepository commentRepository, VideoCacheUtil videoCacheUtil){
+    public CommentService(CommentRepository commentRepository, VideoCacheUtil videoCacheUtil, CommentFcmUtil commentFcmUtil){
         this.commentRepository = commentRepository;
         this.videoCacheUtil = videoCacheUtil;
+        this.commentFcmUtil = commentFcmUtil;
     }
 
 
@@ -49,6 +51,9 @@ public class CommentService {
 
         // redis 에 댓글 수 저장 (증가)
         videoCacheUtil.increaseCommentCount(video);
+
+        // 푸시알림 보내기
+        commentFcmUtil.sendAddCommentNotification(video.getUser(), comment);
 
         return comment;
     }

--- a/src/main/java/hatch/hatchserver2023/global/config/firebase/FcmNotificationUtil.java
+++ b/src/main/java/hatch/hatchserver2023/global/config/firebase/FcmNotificationUtil.java
@@ -16,7 +16,7 @@ public class FcmNotificationUtil {
 
     // 푸시 알림 유형. 이곳에 상수값을 추가해서 사용할 것. key 값이 type 인 데이터의 value 값으로 사용됨
     public static final String TYPE_SEND_CHAT_MESSAGE = "SEND_CHAT_MESSAGE";
-//    public static final String TYPE_ADD_COMMENT = "ADD_COMMENT"; // 예시
+    public static final String TYPE_ADD_COMMENT = "ADD_COMMENT";
     
     private final FcmTokenDao fcmTokenDao;
 


### PR DESCRIPTION
🏷️ Jira issue : HH-418

― PR 유형 ―
- 기능 추가


<br>

## 📑 작업 내용 
- 댓글 작성 시 푸시알림 추가


<br>

## 📌 주요 집중 포인트
FcmNotificationUtil.java와 ChatFcmUtil.java 참고하면서 코드 짰습니다!

푸시알림 형식을 어떻게 할지 고민이 좀 됐는데,
title을 댓글 내용, content를 댓글 작성자로 했습니다.

예를 들어, 김수빈 사용자가 안녕하세요~ 라는 댓글을 작성했을 때,

>  title로 안녕하세요~, content로 김수빈 사용자가 댓글을 남겼습니다.

 형식으로 했습니다.
<br>

## 🔥 어려웠던 부분 & 트러블 슈팅
이거는 토큰 유효성 버그인가 싶어서 남깁니다.

user33으로 테스트했고 token은 그냥 token 이라는 문자열입니다.
댓글을 작성했을 때,  FcmNotificationUtil.send() 메서드에 접근까지 가능하더라고요!

Firebase 서버에서 자체적으로 유효성 검사를 하는거겠죠?

<br>

## 🐣 앞으로 할 일
- 이브와 보고서 작성
- 졸프 발표자료 만들기
