### PR TITLE
[redis-cache] 좋아요 캐싱 로직 버그 수정

### DIFF
--- a/src/main/java/hatch/hatchserver2023/domain/like/application/LikeCacheUtil.java
+++ b/src/main/java/hatch/hatchserver2023/domain/like/application/LikeCacheUtil.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Slf4j
@@ -191,12 +192,18 @@ public class LikeCacheUtil {
             // status 가 add인가 delete인가에 따라서 like 생성
             Like like;
             if(status.equals(CACHE_LIKE_INFO_ADD)){
-                //add 이면 like 객체 새로 생성
-                like = Like.builder()
-                        .user(user)
-                        .video(video).build();
-                addLikes.add(like);
-                log.info("[SCHEDULED] added like info user : {}, video : {}", like.getUser().getNickname(), like.getVideo().getTitle());
+                //add 이면 이미 DB에 존재하는 데이터인지 확인
+                Optional<Like> likeOp = likeRepository.findByVideoAndUser(video, user);
+                if(likeOp.isPresent()) {
+                    log.info("[SCHEDULED] this like already exist. skip");
+                }else{
+                    //존재하지 않으면 like 객체 새로 생성
+                    like = Like.builder()
+                            .user(user)
+                            .video(video).build();
+                    addLikes.add(like);
+                    log.info("[SCHEDULED] added like info user : {}, video : {}", like.getUser().getNickname(), like.getVideo().getTitle());
+                }
             }
             else if(status.equals(CACHE_LIKE_INFO_DELETE)){
                 // delete 이면 RDB 에서 삭제할 데이터를 가져옴


### PR DESCRIPTION
🏷️ Jira issue : 

― PR 유형 ―
- 기존 기능 수정


<br>

## 📑 작업 내용 
- 좋아요 캐싱 로직 버그 수정 : add 상태의 좋아요 캐시 데이터의 경우 이미 like 된 데이터가 DB 에 존재하는지 확인하는 로직 추가

